### PR TITLE
Add HTTPS/SSL Support

### DIFF
--- a/config/sample_xconfadmin.conf
+++ b/config/sample_xconfadmin.conf
@@ -73,7 +73,10 @@ xconfwebconfig {
     // HTTP server settings including port, timeouts, and feature toggles
     
     server {
-        port = 9001                              // HTTP server port (default: 9001)
+        port = 9444                               // HTTPS server port
+        https_enabled = true                      // Enable HTTPS
+        cert_file = "/etc/ssl/xconf/xconf.crt"    // SSL certificate file
+        key_file = "/etc/ssl/xconf/xconf.key"     // SSL private key file
         read_timeout_in_secs = 5                 // Maximum time to read request (seconds)
         write_timeout_in_secs = 50               // Maximum time to write response (seconds)
         metrics_enabled = true                   // Enable Prometheus metrics endpoint (/metrics)
@@ -307,9 +310,10 @@ xconfwebconfig {
     // SSL/TLS certificate configuration for HTTPS clients
     
     http_client {
-        ca_comodo_cert_file= ""                     // CA certificate file path (PEM format)
-        cert_file = ""                              // Client certificate file path (PEM format)
-        private_key_file = ""                       // Private key file path (PEM format)
+        ca_comodo_cert_file= "/etc/ssl/xconf/xconf.crt"                     // CA certificate file path (PEM format)
+        cert_file = "/etc/ssl/xconf/xconf.crt"                              // Client certificate file path (PEM format)
+        key_file = "/etc/ssl/xconf/xconf.key"     // SSL private key file
+        private_key_file = "/etc/ssl/xconf/xconf.key"                       // Private key file path (PEM format)
     }
     
     // =============================


### PR DESCRIPTION
   Adds HTTPS support to XConf services with TLS encryption.

   **Changes:**
   - Configure SSL/TLS in service config files
   - Update endpoints to use HTTPS (ports 9443, 9444, 8443)
   - Add certificate paths for TLS validation
   - Enable secure inter-service communication

   **Testing:** All services start and respond correctly on HTTPS endpoints.

   **Requirements:** SSL certificates at `/etc/ssl/xconf/xconf.crt` and `/etc/ssl/xconf/xconf.key`