### PR TITLE
Merge pull request #93 from rdkcentral/macList_validation

### DIFF
--- a/adminapi/queries/firmware_rule_service.go
+++ b/adminapi/queries/firmware_rule_service.go
@@ -408,6 +408,11 @@ func validateOneFirmewareRule(firmwareRule corefw.FirmwareRule) error {
 		return err
 	}
 
+	err = validateMacListReferences(firmwareRule)
+	if err != nil {
+		return err
+	}
+
 	return xshared.ValidateApplicationType(firmwareRule.ApplicationType)
 }
 
@@ -916,4 +921,20 @@ func GetFirmwareRuleById(id string) *corefw.FirmwareRule {
 		return nil
 	}
 	return fr
+}
+
+// validateMacListReferences validates that all MAC lists referenced in the firmware rule exist
+func validateMacListReferences(firmwareRule corefw.FirmwareRule) error {
+	if firmwareRule.GetRule() == nil {
+		return nil
+	}
+	macListIds := re.GetFixedArgsFromRuleByFreeArgAndOperation(*firmwareRule.GetRule(), "eStbMac", re.StandardOperationInList)
+	for _, macListId := range macListIds {
+		macList, err := shared.GetGenericNamedListOneByTypeNonCached(macListId, shared.MAC_LIST)
+		if err != nil || macList == nil {
+			return xwcommon.NewRemoteErrorAS(http.StatusBadRequest,
+				firmwareRule.Name+": Referenced MAC list '"+macListId+"' does not exist")
+		}
+	}
+	return nil
 }

--- a/adminapi/queries/firmware_rule_service.go
+++ b/adminapi/queries/firmware_rule_service.go
@@ -931,9 +931,13 @@ func validateMacListReferences(firmwareRule corefw.FirmwareRule) error {
 	macListIds := re.GetFixedArgsFromRuleByFreeArgAndOperation(*firmwareRule.GetRule(), "eStbMac", re.StandardOperationInList)
 	for _, macListId := range macListIds {
 		macList, err := shared.GetGenericNamedListOneByTypeNonCached(macListId, shared.MAC_LIST)
-		if err != nil || macList == nil {
+		if err != nil && !strings.Contains(err.Error(), "not found") {
+			return xwcommon.NewRemoteErrorAS(http.StatusInternalServerError,
+				fmt.Sprintf("%s (id=%s): Error retrieving MAC list '%s': %v", firmwareRule.Name, firmwareRule.ID, macListId, err))
+		}
+		if macList == nil {
 			return xwcommon.NewRemoteErrorAS(http.StatusBadRequest,
-				firmwareRule.Name+": Referenced MAC list '"+macListId+"' does not exist")
+				fmt.Sprintf("%s (id=%s): Referenced MAC list '%s' does not exist", firmwareRule.Name, firmwareRule.ID, macListId))
 		}
 	}
 	return nil


### PR DESCRIPTION

This pull request introduces validation to ensure that any MAC lists referenced in a firmware rule actually exist. This helps prevent errors caused by referencing non-existent MAC lists and improves data integrity in the firmware rule management process.

Firmware rule validation improvements:

* Added a new function `validateMacListReferences` to check that all MAC lists referenced in a firmware rule are present; if any are missing, an error is returned.
* Integrated `validateMacListReferences` into the `validateOneFirmewareRule` function, so MAC list existence is now checked as part of the firmware rule validation workflow.