### PR TITLE
Add error logging for negative scenarios to improve visibility

### DIFF
--- a/adminapi/configuration/ip-macrule/ip_mac_ruleconfig_handler.go
+++ b/adminapi/configuration/ip-macrule/ip_mac_ruleconfig_handler.go
@@ -8,6 +8,8 @@ import (
 	"github.com/rdkcentral/xconfadmin/common"
 	ccommon "github.com/rdkcentral/xconfadmin/common"
 	xhttp "github.com/rdkcentral/xconfadmin/http"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func GetIpMacRuleConfigurationHandler(w http.ResponseWriter, r *http.Request) {
@@ -24,6 +26,7 @@ func GetIpMacRuleConfigurationHandler(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write(b)
 	} else {
+		log.WithFields(log.Fields{"error": err}).Error("failed to marshal ip mac rule config")
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 	}

--- a/adminapi/queries/percentfilter_handler.go
+++ b/adminapi/queries/percentfilter_handler.go
@@ -81,6 +81,7 @@ func GetCalculatedHashAndPercentHandler(w http.ResponseWriter, r *http.Request) 
 	}
 	jsonResponse, err := json.Marshal(response)
 	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Error("failed to marshal JSON response")
 		http.Error(w, "Failed to marshal JSON response", http.StatusInternalServerError)
 		return
 	}
@@ -99,6 +100,7 @@ func UpdatePercentFilterGlobalHandler(w http.ResponseWriter, r *http.Request) {
 	// r.Body is already drained in the middleware
 	xw, ok := w.(*xwhttp.XResponseWriter)
 	if !ok {
+		log.Error("failed to cast responsewriter in UpdatePercentFilterGlobalHandler")
 		xhttp.AdminError(w, xwcommon.NewRemoteErrorAS(http.StatusInternalServerError, "responsewriter cast error"))
 		return
 	}
@@ -149,6 +151,7 @@ func GetPercentFilterGlobalHandler(w http.ResponseWriter, r *http.Request) {
 
 	globalpercent, err := GetPercentFilterGlobal(applicationType)
 	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Error("failed to get global percent filter")
 		xhttp.WriteAdminErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("unable to get globalpercent reponse. error: %v", err))
 		return
 	}
@@ -209,6 +212,7 @@ func GetGlobalPercentFilterHandler(w http.ResponseWriter, r *http.Request) {
 
 	globalpercent, err := GetGlobalPercentFilter(applicationType)
 	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Error("failed to get global percent filter")
 		xhttp.WriteAdminErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("unable to get globalpercent reponse. error: %v", err))
 		return
 	}
@@ -265,6 +269,7 @@ func GetCalculatedHashAndPercent(w http.ResponseWriter, r *http.Request) {
 	}
 	jsonResponse, err := json.Marshal(response)
 	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Error("failed to marshal JSON response")
 		http.Error(w, "Failed to marshal JSON response", http.StatusInternalServerError)
 		return
 	}

--- a/adminapi/xcrp/recooking_lockdown_settings_handler.go
+++ b/adminapi/xcrp/recooking_lockdown_settings_handler.go
@@ -57,6 +57,7 @@ func PostRecookingLockdownSettingsHandler(w http.ResponseWriter, r *http.Request
 	var lockdownSettingFromDB *common.LockdownSettings
 	lockdownSettingFromDB, err = lockdown.GetLockdownSettings()
 	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Error("failed to get lockdown settings")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/adminapi/xcrp/recooking_status_handler.go
+++ b/adminapi/xcrp/recooking_status_handler.go
@@ -26,12 +26,14 @@ type RecookingStatus struct {
 func GetRecookingStatusHandler(w http.ResponseWriter, r *http.Request) {
 	cc, ok := db.GetDatabaseClient().(*db.CassandraClient)
 	if !ok {
+		log.Error("internal server error: Database client is not Cassandra client")
 		http.Error(w, "Database client is not Cassandra client", http.StatusInternalServerError)
 		return
 	}
 
 	status, updatedTime, err := cc.CheckFinalRecookingStatus(DEFAULT_XCRP_SERVICE_NAME)
 	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Error("failed to check recooking status")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -60,17 +62,20 @@ func GetRecookingStatusHandler(w http.ResponseWriter, r *http.Request) {
 func GetRecookingStatusDetailsHandler(w http.ResponseWriter, r *http.Request) {
 	cc, ok := db.GetDatabaseClient().(*db.CassandraClient)
 	if !ok {
+		log.Error("Database client is not Cassandra client")
 		http.Error(w, "Database client is not Cassandra client", http.StatusInternalServerError)
 		return
 	}
 	statuses, err := cc.GetRecookingStatusDetails()
 	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Error("failed to get recooking status details")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	response, err := json.Marshal(statuses)
 	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Error("failed to marshal recooking status details")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
- Add log.Error for 500 error paths in recooking_status_handler.go
- Add log.Error for lockdown settings failure in recooking_lockdown_settings_handler.go
- Add log.Error for marshal failures and missing error logging in percentfilter_handler.go
- Add log.Error for marshal failure in ip_mac_ruleconfig_handler.go