### PR TITLE
Add model and IP address list reference validation for rule conditions

### DIFF
--- a/adminapi/queries/baserule_validator.go
+++ b/adminapi/queries/baserule_validator.go
@@ -199,7 +199,8 @@ func checkFixedArgValue(condition re.Condition, fp func(string) bool) error {
 		}
 		freeArgName := condition.GetFreeArg().GetName()
 		if freeArgName == xwcommon.MODEL || freeArgName == logupload.Model {
-			if !xcommon.IsExistModel(fixedArgValue) {
+			normalizedModel := strings.ToUpper(strings.TrimSpace(fixedArgValue))
+			if !xcommon.IsExistModel(normalizedModel) {
 				return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "Model does not exist: "+fixedArgValue)
 			}
 		}

--- a/adminapi/queries/baserule_validator.go
+++ b/adminapi/queries/baserule_validator.go
@@ -183,11 +183,25 @@ func checkFixedArgValue(condition re.Condition, fp func(string) bool) error {
 				return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "Incorrect Collection Value")
 			}
 		}
+	} else if re.StandardOperationInList == operation {
+		fixedArgValue := condition.GetFixedArg().GetValue().(string)
+		freeArgName := condition.GetFreeArg().GetName()
+		if freeArgName == xwcommon.IP_ADDRESS || freeArgName == logupload.EstbIp {
+			if GetNamespacedListByIdAndType(fixedArgValue, shared.IP_LIST) == nil {
+				return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "IP list does not exist: "+fixedArgValue)
+			}
+		}
 	} else if re.StandardOperationIs == operation {
 		fixedArgValue := condition.GetFixedArg().GetValue().(string)
 		//fixedArgValue := coreef.trimSingleQuote (condition.GetFixedArg().String())
 		if !fp(fixedArgValue) {
 			return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, condition.FreeArg.GetName()+" is invalid: "+fixedArgValue)
+		}
+		freeArgName := condition.GetFreeArg().GetName()
+		if freeArgName == xwcommon.MODEL || freeArgName == logupload.Model {
+			if !xcommon.IsExistModel(fixedArgValue) {
+				return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "Model does not exist: "+fixedArgValue)
+			}
 		}
 	} else if re.StandardOperationPercent == operation {
 		ret, err := checkPercentOperation(condition)

--- a/adminapi/queries/baserule_validator.go
+++ b/adminapi/queries/baserule_validator.go
@@ -201,7 +201,7 @@ func checkFixedArgValue(condition re.Condition, fp func(string) bool) error {
 		if freeArgName == xwcommon.MODEL || freeArgName == logupload.Model {
 			normalizedModel := strings.ToUpper(strings.TrimSpace(fixedArgValue))
 			if !xcommon.IsExistModel(normalizedModel) {
-				return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "Model does not exist: "+fixedArgValue)
+				return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "Model does not exist: "+normalizedModel)
 			}
 		}
 	} else if re.StandardOperationPercent == operation {

--- a/adminapi/queries/baserule_validator_test.go
+++ b/adminapi/queries/baserule_validator_test.go
@@ -23,7 +23,10 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	xcommon "github.com/rdkcentral/xconfadmin/common"
+	xwcommon "github.com/rdkcentral/xconfwebconfig/common"
 	re "github.com/rdkcentral/xconfwebconfig/rulesengine"
+	"github.com/rdkcentral/xconfwebconfig/shared"
+	logupload "github.com/rdkcentral/xconfwebconfig/shared/logupload"
 )
 
 func TestEqualFreeArgNames_Equal(t *testing.T) {
@@ -1272,4 +1275,123 @@ func TestRunGlobalValidation_InvalidOperation(t *testing.T) {
 
 	err := RunGlobalValidation(rule, GetAllowedOperations)
 	assert.Error(t, err)
+}
+
+// Tests for new validation logic - IN_LIST operation on IP_ADDRESS field
+
+func TestCheckFixedArgValue_InListOperationOnIPAddress_MissingIPList(t *testing.T) {
+	condition := re.Condition{
+		FreeArg:   &re.FreeArg{Name: xwcommon.IP_ADDRESS},
+		Operation: re.StandardOperationInList,
+		FixedArg:  re.NewFixedArg("NONEXISTENT_IP_LIST"),
+	}
+
+	err := checkFixedArgValue(condition, isNotBlank)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "IP list does not exist")
+}
+
+func TestCheckFixedArgValue_InListOperationOnIPAddress_ValidIPList(t *testing.T) {
+	DeleteAllEntities()
+
+	// Create a valid IP list using the package-level helper and service function
+	ipList := makeGenericList("TEST_IP_LIST", shared.IP_LIST, []string{"192.168.1.0/24"})
+	CreateNamespacedList(ipList, false)
+
+	condition := re.Condition{
+		FreeArg:   &re.FreeArg{Name: xwcommon.IP_ADDRESS},
+		Operation: re.StandardOperationInList,
+		FixedArg:  re.NewFixedArg("TEST_IP_LIST"),
+	}
+
+	err := checkFixedArgValue(condition, isNotBlank)
+	assert.NoError(t, err)
+
+	DeleteAllEntities()
+}
+
+func TestCheckFixedArgValue_InListOperationOnEstbIp_MissingIPList(t *testing.T) {
+	condition := re.Condition{
+		FreeArg:   &re.FreeArg{Name: logupload.EstbIp},
+		Operation: re.StandardOperationInList,
+		FixedArg:  re.NewFixedArg("MISSING_LIST_ID"),
+	}
+
+	err := checkFixedArgValue(condition, isNotBlank)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "IP list does not exist")
+}
+
+func TestCheckFixedArgValue_InListOperationOnNonIPField_NoListValidation(t *testing.T) {
+	// For non-IP fields, IN_LIST should not validate IP list existence
+	condition := re.Condition{
+		FreeArg:   &re.FreeArg{Name: "model"},
+		Operation: re.StandardOperationInList,
+		FixedArg:  re.NewFixedArg("ANYTHING"),
+	}
+
+	// Non-IP field: no IP list validation should occur
+	err := checkFixedArgValue(condition, isNotBlank)
+	assert.NoError(t, err)
+}
+
+// Tests for new validation logic - IS operation on MODEL field
+
+func TestCheckFixedArgValue_IsOperationOnModel_MissingModel(t *testing.T) {
+	condition := re.Condition{
+		FreeArg:   &re.FreeArg{Name: xwcommon.MODEL},
+		Operation: re.StandardOperationIs,
+		FixedArg:  re.NewFixedArg("NONEXISTENT_MODEL_XYZ_123"),
+	}
+
+	err := checkFixedArgValue(condition, isNotBlank)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Model does not exist")
+}
+
+func TestCheckFixedArgValue_IsOperationOnModel_ValidModel(t *testing.T) {
+	DeleteAllEntities()
+
+	// Create a valid model using the service function
+	model := &shared.Model{
+		ID:          "TEST_MODEL",
+		Description: "Test Model",
+	}
+	CreateModel(model)
+
+	condition := re.Condition{
+		FreeArg:   &re.FreeArg{Name: xwcommon.MODEL},
+		Operation: re.StandardOperationIs,
+		FixedArg:  re.NewFixedArg("TEST_MODEL"),
+	}
+
+	err := checkFixedArgValue(condition, isNotBlank)
+	assert.NoError(t, err)
+
+	DeleteAllEntities()
+}
+
+func TestCheckFixedArgValue_IsOperationOnLoguploadModel_MissingModel(t *testing.T) {
+	condition := re.Condition{
+		FreeArg:   &re.FreeArg{Name: logupload.Model},
+		Operation: re.StandardOperationIs,
+		FixedArg:  re.NewFixedArg("MISSING_MODEL_ID"),
+	}
+
+	err := checkFixedArgValue(condition, isNotBlank)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Model does not exist")
+}
+
+func TestCheckFixedArgValue_IsOperationOnNonModelField_NoModelValidation(t *testing.T) {
+	// For non-MODEL fields, IS should not validate model existence
+	condition := re.Condition{
+		FreeArg:   &re.FreeArg{Name: "environment"},
+		Operation: re.StandardOperationIs,
+		FixedArg:  re.NewFixedArg("ANYTHING"),
+	}
+
+	// Non-MODEL field: no model validation should occur
+	err := checkFixedArgValue(condition, isNotBlank)
+	assert.NoError(t, err)
 }

--- a/adminapi/queries/baserule_validator_test.go
+++ b/adminapi/queries/baserule_validator_test.go
@@ -1292,6 +1292,7 @@ func TestCheckFixedArgValue_InListOperationOnIPAddress_MissingIPList(t *testing.
 }
 
 func TestCheckFixedArgValue_InListOperationOnIPAddress_ValidIPList(t *testing.T) {
+	SkipIfMockDatabase(t) // Service test uses ds.GetCachedSimpleDao() directly
 	DeleteAllEntities()
 
 	// Create a valid IP list using the package-level helper and service function
@@ -1350,6 +1351,7 @@ func TestCheckFixedArgValue_IsOperationOnModel_MissingModel(t *testing.T) {
 }
 
 func TestCheckFixedArgValue_IsOperationOnModel_ValidModel(t *testing.T) {
+	SkipIfMockDatabase(t) // Service test uses ds.GetCachedSimpleDao() directly
 	DeleteAllEntities()
 
 	// Create a valid model using the service function

--- a/adminapi/queries/percentage_bean_service.go
+++ b/adminapi/queries/percentage_bean_service.go
@@ -38,7 +38,6 @@ import (
 	xwcommon "github.com/rdkcentral/xconfwebconfig/common"
 	xwhttp "github.com/rdkcentral/xconfwebconfig/http"
 	re "github.com/rdkcentral/xconfwebconfig/rulesengine"
-	ru "github.com/rdkcentral/xconfwebconfig/rulesengine"
 	"github.com/rdkcentral/xconfwebconfig/shared"
 	coreef "github.com/rdkcentral/xconfwebconfig/shared/estbfirmware"
 	"github.com/rdkcentral/xconfwebconfig/shared/firmware"
@@ -258,7 +257,7 @@ func CreatePercentageBean(bean *coreef.PercentageBean, applicationType string, f
 	firmware.SortConfigEntry(bean.Distributions)
 
 	fRule := coreef.ConvertPercentageBeanToFirmwareRule(*bean)
-	ru.NormalizeConditions(&fRule.Rule)
+	re.NormalizeConditions(&fRule.Rule)
 	if err := firmware.CreateFirmwareRuleOneDB(fRule); err != nil {
 		return xwhttp.NewResponseEntity(http.StatusInternalServerError, err, nil)
 	}
@@ -308,7 +307,7 @@ func UpdatePercentageBean(bean *coreef.PercentageBean, applicationType string, f
 	firmware.SortConfigEntry(bean.Distributions)
 
 	newRule := coreef.ConvertPercentageBeanToFirmwareRule(*bean)
-	ru.NormalizeConditions(&newRule.Rule)
+	re.NormalizeConditions(&newRule.Rule)
 	if err := firmware.CreateFirmwareRuleOneDB(newRule); err != nil {
 		return xwhttp.NewResponseEntity(http.StatusInternalServerError, err, nil)
 	}

--- a/adminapi/queries/percentage_bean_service.go
+++ b/adminapi/queries/percentage_bean_service.go
@@ -234,6 +234,10 @@ func CreatePercentageBean(bean *coreef.PercentageBean, applicationType string, f
 		return xwhttp.NewResponseEntity(http.StatusConflict, fmt.Errorf("Entity with id %s ApplicationType doesn't match", bean.ID), nil)
 	}
 
+	if err := validatePercentageBeanReferences(bean); err != nil {
+		return xwhttp.NewResponseEntity(http.StatusBadRequest, err, nil)
+	}
+
 	if err := firmware.ValidateRuleName(bean.ID, bean.Name, applicationType); err != nil {
 		return xwhttp.NewResponseEntity(http.StatusBadRequest, err, nil)
 	}
@@ -280,6 +284,10 @@ func UpdatePercentageBean(bean *coreef.PercentageBean, applicationType string, f
 		return xwhttp.NewResponseEntity(http.StatusBadRequest, fmt.Errorf("ApplicationType cannot be changed: Existing value:%s New Value: %s", fRule.ApplicationType, bean.ApplicationType), nil)
 	}
 
+	if err := validatePercentageBeanReferences(bean); err != nil {
+		return xwhttp.NewResponseEntity(http.StatusBadRequest, err, nil)
+	}
+
 	if err := firmware.ValidateRuleName(bean.ID, bean.Name, applicationType); err != nil {
 		return xwhttp.NewResponseEntity(http.StatusBadRequest, err, nil)
 	}
@@ -323,6 +331,24 @@ func DeletePercentageBean(id string, app string) *xwhttp.ResponseEntity {
 	}
 
 	return xwhttp.NewResponseEntity(http.StatusNoContent, nil, nil)
+}
+
+func validatePercentageBeanReferences(bean *coreef.PercentageBean) error {
+	if !common.IsExistModel(bean.Model) {
+		return fmt.Errorf("Model: %s does not exist", bean.Model)
+	}
+
+	if !xutil.IsBlank(bean.Whitelist) && GetNamespacedListByIdAndType(bean.Whitelist, shared.IP_LIST) == nil {
+		return fmt.Errorf("IP address list '%s' does not exist", bean.Whitelist)
+	}
+
+	if bean.OptionalConditions != nil && len(re.ToConditions(bean.OptionalConditions)) > 0 {
+		if err := RunGlobalValidation(*bean.OptionalConditions, GetFirmwareRuleAllowedOperations); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func createCanaries(newBean *coreef.PercentageBean, oldRule *firmware.FirmwareRule, fields log.Fields) {

--- a/adminapi/queries/percentage_bean_service.go
+++ b/adminapi/queries/percentage_bean_service.go
@@ -337,7 +337,8 @@ func validatePercentageBeanReferences(bean *coreef.PercentageBean) error {
 	if xutil.IsBlank(bean.Model) {
 		return errors.New("Model is empty")
 	}
-	if !common.IsExistModel(bean.Model) {
+	normalizedModel := strings.ToUpper(strings.TrimSpace(bean.Model))
+	if !common.IsExistModel(normalizedModel) {
 		return fmt.Errorf("Model: %s does not exist", bean.Model)
 	}
 

--- a/adminapi/queries/percentage_bean_service.go
+++ b/adminapi/queries/percentage_bean_service.go
@@ -334,6 +334,9 @@ func DeletePercentageBean(id string, app string) *xwhttp.ResponseEntity {
 }
 
 func validatePercentageBeanReferences(bean *coreef.PercentageBean) error {
+	if xutil.IsBlank(bean.Model) {
+		return errors.New("Model is empty")
+	}
 	if !common.IsExistModel(bean.Model) {
 		return fmt.Errorf("Model: %s does not exist", bean.Model)
 	}

--- a/adminapi/queries/percentage_bean_service.go
+++ b/adminapi/queries/percentage_bean_service.go
@@ -339,7 +339,7 @@ func validatePercentageBeanReferences(bean *coreef.PercentageBean) error {
 	}
 	normalizedModel := strings.ToUpper(strings.TrimSpace(bean.Model))
 	if !common.IsExistModel(normalizedModel) {
-		return fmt.Errorf("Model: %s does not exist", bean.Model)
+		return fmt.Errorf("Model: %s does not exist", normalizedModel)
 	}
 
 	if !xutil.IsBlank(bean.Whitelist) && GetNamespacedListByIdAndType(bean.Whitelist, shared.IP_LIST) == nil {

--- a/adminapi/queries/percentage_bean_service.go
+++ b/adminapi/queries/percentage_bean_service.go
@@ -347,7 +347,12 @@ func validatePercentageBeanReferences(bean *coreef.PercentageBean) error {
 	}
 
 	if bean.OptionalConditions != nil && len(re.ToConditions(bean.OptionalConditions)) > 0 {
-		if err := RunGlobalValidation(*bean.OptionalConditions, GetFirmwareRuleAllowedOperations); err != nil {
+		err := ValidateRuleStructure(bean.OptionalConditions)
+		if err != nil {
+			return err
+		}
+		err = RunGlobalValidation(*bean.OptionalConditions, GetFeatureRuleAllowedOperations)
+		if err != nil {
 			return err
 		}
 	}

--- a/adminapi/queries/percentage_bean_service_test.go
+++ b/adminapi/queries/percentage_bean_service_test.go
@@ -25,6 +25,9 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
+	xwcommon "github.com/rdkcentral/xconfwebconfig/common"
+	re "github.com/rdkcentral/xconfwebconfig/rulesengine"
+	"github.com/rdkcentral/xconfwebconfig/shared"
 	coreef "github.com/rdkcentral/xconfwebconfig/shared/estbfirmware"
 )
 
@@ -539,4 +542,157 @@ func TestDeletePercentageBean_ResponseEntity_AppTypeMismatch(t *testing.T) {
 	assert.NotNil(t, response)
 	assert.Equal(t, http.StatusNotFound, response.Status)
 	assert.NotNil(t, response.Error)
+}
+
+// Tests for validatePercentageBeanReferences
+
+func TestValidatePercentageBeanReferences_InvalidModel(t *testing.T) {
+	DeleteAllEntities()
+
+	bean := &coreef.PercentageBean{
+		ID:              "test-bean-id",
+		Name:            "test-bean",
+		Model:           "NONEXISTENT_MODEL_XYZ",
+		ApplicationType: "stb",
+	}
+
+	err := validatePercentageBeanReferences(bean)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Model")
+	assert.Contains(t, err.Error(), "does not exist")
+}
+
+func TestValidatePercentageBeanReferences_ValidModel(t *testing.T) {
+	DeleteAllEntities()
+
+	// Create a valid model first
+	model := &shared.Model{
+		ID:          "TEST_MODEL",
+		Description: "Test Model",
+	}
+	CreateModel(model)
+
+	bean := &coreef.PercentageBean{
+		ID:              "test-bean-id",
+		Name:            "test-bean",
+		Model:           "TEST_MODEL",
+		ApplicationType: "stb",
+	}
+
+	err := validatePercentageBeanReferences(bean)
+	assert.NoError(t, err)
+
+	DeleteAllEntities()
+}
+
+func TestValidatePercentageBeanReferences_InvalidIPList(t *testing.T) {
+	DeleteAllEntities()
+
+	// Create a valid model first
+	model := &shared.Model{
+		ID:          "TEST_MODEL",
+		Description: "Test Model",
+	}
+	CreateModel(model)
+
+	bean := &coreef.PercentageBean{
+		ID:              "test-bean-id",
+		Name:            "test-bean",
+		Model:           "TEST_MODEL",
+		Whitelist:       "NONEXISTENT_IP_LIST",
+		ApplicationType: "stb",
+	}
+
+	err := validatePercentageBeanReferences(bean)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "IP address list")
+	assert.Contains(t, err.Error(), "does not exist")
+
+	DeleteAllEntities()
+}
+
+func TestValidatePercentageBeanReferences_ValidIPList(t *testing.T) {
+	DeleteAllEntities()
+
+	// Create a valid model
+	model := &shared.Model{
+		ID:          "TEST_MODEL",
+		Description: "Test Model",
+	}
+	CreateModel(model)
+
+	// Create a valid IP list
+	ipList := makeGenericList("TEST_IP_LIST", shared.IP_LIST, []string{"192.168.1.0/24"})
+	CreateNamespacedList(ipList, false)
+
+	bean := &coreef.PercentageBean{
+		ID:              "test-bean-id",
+		Name:            "test-bean",
+		Model:           "TEST_MODEL",
+		Whitelist:       "TEST_IP_LIST",
+		ApplicationType: "stb",
+	}
+
+	err := validatePercentageBeanReferences(bean)
+	assert.NoError(t, err)
+
+	DeleteAllEntities()
+}
+
+func TestValidatePercentageBeanReferences_BlankWhitelist(t *testing.T) {
+	DeleteAllEntities()
+
+	// Create a valid model
+	model := &shared.Model{
+		ID:          "TEST_MODEL",
+		Description: "Test Model",
+	}
+	CreateModel(model)
+
+	bean := &coreef.PercentageBean{
+		ID:              "test-bean-id",
+		Name:            "test-bean",
+		Model:           "TEST_MODEL",
+		Whitelist:       "", // Blank whitelist should be allowed
+		ApplicationType: "stb",
+	}
+
+	err := validatePercentageBeanReferences(bean)
+	assert.NoError(t, err)
+
+	DeleteAllEntities()
+}
+
+func TestValidatePercentageBeanReferences_InvalidOptionalConditions(t *testing.T) {
+	DeleteAllEntities()
+
+	// Create a valid model
+	model := &shared.Model{
+		ID:          "TEST_MODEL",
+		Description: "Test Model",
+	}
+	CreateModel(model)
+
+	// Create optional condition referencing a model that doesn't exist
+	optionalConditions := &re.Rule{
+		Condition: &re.Condition{
+			FreeArg:   &re.FreeArg{Name: xwcommon.MODEL},
+			Operation: re.StandardOperationIs,
+			FixedArg:  re.NewFixedArg("INVALID_MODEL"),
+		},
+	}
+
+	bean := &coreef.PercentageBean{
+		ID:                 "test-bean-id",
+		Name:               "test-bean",
+		Model:              "TEST_MODEL",
+		ApplicationType:    "stb",
+		OptionalConditions: optionalConditions,
+	}
+
+	err := validatePercentageBeanReferences(bean)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Model does not exist")
+
+	DeleteAllEntities()
 }

--- a/adminapi/queries/percentage_bean_service_test.go
+++ b/adminapi/queries/percentage_bean_service_test.go
@@ -563,6 +563,7 @@ func TestValidatePercentageBeanReferences_InvalidModel(t *testing.T) {
 }
 
 func TestValidatePercentageBeanReferences_ValidModel(t *testing.T) {
+	SkipIfMockDatabase(t) // Service test uses ds.GetCachedSimpleDao() directly
 	DeleteAllEntities()
 
 	// Create a valid model first
@@ -586,6 +587,7 @@ func TestValidatePercentageBeanReferences_ValidModel(t *testing.T) {
 }
 
 func TestValidatePercentageBeanReferences_InvalidIPList(t *testing.T) {
+	SkipIfMockDatabase(t) // Service test uses ds.GetCachedSimpleDao() directly
 	DeleteAllEntities()
 
 	// Create a valid model first
@@ -612,6 +614,7 @@ func TestValidatePercentageBeanReferences_InvalidIPList(t *testing.T) {
 }
 
 func TestValidatePercentageBeanReferences_ValidIPList(t *testing.T) {
+	SkipIfMockDatabase(t) // Service test uses ds.GetCachedSimpleDao() directly
 	DeleteAllEntities()
 
 	// Create a valid model
@@ -640,6 +643,7 @@ func TestValidatePercentageBeanReferences_ValidIPList(t *testing.T) {
 }
 
 func TestValidatePercentageBeanReferences_BlankWhitelist(t *testing.T) {
+	SkipIfMockDatabase(t) // Service test uses ds.GetCachedSimpleDao() directly
 	DeleteAllEntities()
 
 	// Create a valid model
@@ -664,6 +668,7 @@ func TestValidatePercentageBeanReferences_BlankWhitelist(t *testing.T) {
 }
 
 func TestValidatePercentageBeanReferences_InvalidOptionalConditions(t *testing.T) {
+	SkipIfMockDatabase(t) // Service test uses ds.GetCachedSimpleDao() directly
 	DeleteAllEntities()
 
 	// Create a valid model


### PR DESCRIPTION
## Summary
This PR strengthens input payload validation for percentage bean and optional condition handling to prevent invalid model and IP list references from being accepted.

## Changes
- In `baserule_validator.go`, added validation for `IN_LIST` conditions on `IP_ADDRESS` to ensure the referenced namespaced IP list exists.
- In `baserule_validator.go`, added validation for `IS` conditions on `MODEL` to ensure the referenced model exists.
- In `percentage_bean_service.go`, introduced `validatePercentageBeanReferences()` to validate model, whitelist IP list, and optional conditions.
- In `percentage_bean_service.go`, wired `validatePercentageBeanReferences()` into both `CreatePercentageBean` and `UpdatePercentageBean` flows so invalid references fail early with `Bad Request`.