### PR TITLE
Validate firmware template references and standardize validation error context

### DIFF
--- a/adminapi/dcm/dcmformula_service.go
+++ b/adminapi/dcm/dcmformula_service.go
@@ -162,7 +162,7 @@ func dcmRuleValidate(dfrule *logupload.DCMGenericRule) *xwhttp.ResponseEntity {
 	}
 	err = queries.RunGlobalValidation(*dfrule.GetRule(), queries.GetFirmwareRuleAllowedOperations)
 	if err != nil {
-		return xwhttp.NewResponseEntity(http.StatusBadRequest, err, nil)
+		return xwhttp.NewResponseEntity(http.StatusBadRequest, fmt.Errorf("%s: %s", dfrule.Name, err.Error()), nil)
 	}
 	err = validatePercentage(dfrule)
 	if err != nil {

--- a/adminapi/queries/feature_rule_service.go
+++ b/adminapi/queries/feature_rule_service.go
@@ -255,7 +255,7 @@ func ValidateFeatureRule(featureRule *rfc.FeatureRule, applicationType string) e
 	}
 	err = RunGlobalValidation(*featureRule.Rule, GetFeatureRuleAllowedOperations)
 	if err != nil {
-		return err
+		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, featureRule.Name+": "+err.Error())
 	}
 	if featureRule.Name == "" {
 		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "FeatureRule name is blank")

--- a/adminapi/queries/firmware_rule_template_service.go
+++ b/adminapi/queries/firmware_rule_template_service.go
@@ -193,6 +193,12 @@ func validateRule(fr *re.Rule, action *corefw.TemplateApplicableAction) error {
 		if err := checkOperationName(c, GetFirmwareRuleAllowedOperations); err != nil {
 			return err
 		}
+		if (equalOperations(c.GetOperation(), re.StandardOperationIs) && c.GetFreeArg().GetName() == xwcommon.MODEL) ||
+			(equalOperations(c.GetOperation(), re.StandardOperationInList) && c.GetFreeArg().GetName() == xwcommon.IP_ADDRESS) {
+			if err := checkFixedArgValue(*c, isNotBlank); err != nil {
+				return err
+			}
+		}
 	}
 	return validateProperties(action)
 }

--- a/adminapi/queries/firmware_rule_template_service.go
+++ b/adminapi/queries/firmware_rule_template_service.go
@@ -232,11 +232,7 @@ func validateOneFirmwareRT(frt corefw.FirmwareRuleTemplate) error {
 	if !found {
 		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "Invalid action type "+string(frt.ApplicableAction.ActionType)+" in "+frt.GetName())
 	}
-	err := validateRule(frt.GetRule(), frt.ApplicableAction)
-	if err != nil {
-		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, frt.GetName()+": "+err.Error())
-	}
-	return nil
+	return validateRule(frt.GetRule(), frt.ApplicableAction)
 }
 
 func validateAgainstFirmwareRTs(frt *corefw.FirmwareRuleTemplate, entities []*corefw.FirmwareRuleTemplate) error {

--- a/adminapi/queries/firmware_rule_template_service.go
+++ b/adminapi/queries/firmware_rule_template_service.go
@@ -190,11 +190,23 @@ func validateRule(fr *re.Rule, action *corefw.TemplateApplicableAction) error {
 		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "FirmwareRuleTemplate "+fr.Id()+" should have a minimum one condition")
 	}
 	for _, c := range conditions {
+		if c == nil {
+			return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "Condition is null")
+		}
+		if err := checkConditionNullsOrBlanks(*c); err != nil {
+			return err
+		}
+		if err := checkDuplicateFixedArgListItems(*c); err != nil {
+			return err
+		}
 		if err := checkOperationName(c, GetFirmwareRuleAllowedOperations); err != nil {
 			return err
 		}
 		if (equalOperations(c.GetOperation(), re.StandardOperationIs) && c.GetFreeArg().GetName() == xwcommon.MODEL) ||
 			(equalOperations(c.GetOperation(), re.StandardOperationInList) && c.GetFreeArg().GetName() == xwcommon.IP_ADDRESS) {
+			if _, ok := c.GetFixedArg().GetValue().(string); !ok {
+				return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "FixedArg value should be string")
+			}
 			if err := checkFixedArgValue(*c, isNotBlank); err != nil {
 				return err
 			}

--- a/adminapi/queries/firmware_rule_template_service.go
+++ b/adminapi/queries/firmware_rule_template_service.go
@@ -220,7 +220,11 @@ func validateOneFirmwareRT(frt corefw.FirmwareRuleTemplate) error {
 	if !found {
 		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "Invalid action type "+string(frt.ApplicableAction.ActionType)+" in "+frt.GetName())
 	}
-	return validateRule(frt.GetRule(), frt.ApplicableAction)
+	err := validateRule(frt.GetRule(), frt.ApplicableAction)
+	if err != nil {
+		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, frt.GetName()+": "+err.Error())
+	}
+	return nil
 }
 
 func validateAgainstFirmwareRTs(frt *corefw.FirmwareRuleTemplate, entities []*corefw.FirmwareRuleTemplate) error {

--- a/adminapi/queries/firmware_rule_template_service.go
+++ b/adminapi/queries/firmware_rule_template_service.go
@@ -205,7 +205,15 @@ func validateRule(fr *re.Rule, action *corefw.TemplateApplicableAction) error {
 		if (equalOperations(c.GetOperation(), re.StandardOperationIs) && c.GetFreeArg().GetName() == xwcommon.MODEL) ||
 			(equalOperations(c.GetOperation(), re.StandardOperationInList) && c.GetFreeArg().GetName() == xwcommon.IP_ADDRESS) {
 			if _, ok := c.GetFixedArg().GetValue().(string); !ok {
-				return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "FixedArg value should be string")
+				return xwcommon.NewRemoteErrorAS(
+					http.StatusBadRequest,
+					fmt.Sprintf(
+						"FixedArg value should be string for freeArg '%s' with operation '%s', got %T",
+						c.GetFreeArg().GetName(),
+						c.GetOperation(),
+						c.GetFixedArg().GetValue(),
+					),
+				)
 			}
 			if err := checkFixedArgValue(*c, isNotBlank); err != nil {
 				return err

--- a/adminapi/queries/firmware_rule_template_service_test.go
+++ b/adminapi/queries/firmware_rule_template_service_test.go
@@ -372,6 +372,78 @@ func TestCreateFirmwareRT_ValidationError(t *testing.T) {
 	assert.ErrorContains(t, err, "Missing applicable action type")
 }
 
+func TestCreateFirmwareRT_ModelReferenceDoesNotExist(t *testing.T) {
+	DeleteAllEntities()
+	setupTestModels()
+	defer DeleteAllEntities()
+
+	templateJSON := `{
+		"id": "` + uuid.New().String() + `",
+		"name": "MissingModelRef",
+		"priority": 1,
+		"editable": true,
+		"rule": {
+			"condition": {
+				"freeArg": {"type": "STRING", "name": "model"},
+				"operation": "IS",
+				"fixedArg": {
+					"bean": {
+						"value": {"java.lang.String": "NON_EXISTENT_MODEL_FOR_FRT"}
+					}
+				}
+			}
+		},
+		"applicableAction": {
+			"type": ".RuleAction",
+			"actionType": "RULE_TEMPLATE"
+		}
+	}`
+
+	var template firmware.FirmwareRuleTemplate
+	json.Unmarshal([]byte(templateJSON), &template)
+
+	result, err := createFirmwareRT(template)
+	assert.Assert(t, err != nil)
+	assert.Assert(t, result == nil)
+	assert.ErrorContains(t, err, "Model does not exist")
+}
+
+func TestCreateFirmwareRT_IPListReferenceDoesNotExist(t *testing.T) {
+	DeleteAllEntities()
+	setupTestModels()
+	defer DeleteAllEntities()
+
+	templateJSON := `{
+		"id": "` + uuid.New().String() + `",
+		"name": "MissingIPListRef",
+		"priority": 1,
+		"editable": true,
+		"rule": {
+			"condition": {
+				"freeArg": {"type": "STRING", "name": "ipAddress"},
+				"operation": "IN_LIST",
+				"fixedArg": {
+					"bean": {
+						"value": {"java.lang.String": "NON_EXISTENT_IP_LIST_FOR_FRT"}
+					}
+				}
+			}
+		},
+		"applicableAction": {
+			"type": ".RuleAction",
+			"actionType": "RULE_TEMPLATE"
+		}
+	}`
+
+	var template firmware.FirmwareRuleTemplate
+	json.Unmarshal([]byte(templateJSON), &template)
+
+	result, err := createFirmwareRT(template)
+	assert.Assert(t, err != nil)
+	assert.Assert(t, result == nil)
+	assert.ErrorContains(t, err, "IP list does not exist")
+}
+
 func TestCreateFirmwareRT_DuplicateName(t *testing.T) {
 	DeleteAllEntities()
 	setupTestModels()

--- a/adminapi/queries/firmware_rule_template_service_test.go
+++ b/adminapi/queries/firmware_rule_template_service_test.go
@@ -400,7 +400,8 @@ func TestCreateFirmwareRT_ModelReferenceDoesNotExist(t *testing.T) {
 	}`
 
 	var template firmware.FirmwareRuleTemplate
-	json.Unmarshal([]byte(templateJSON), &template)
+	err := json.Unmarshal([]byte(templateJSON), &template)
+	assert.NilError(t, err)
 
 	result, err := createFirmwareRT(template)
 	assert.Assert(t, err != nil)
@@ -436,7 +437,8 @@ func TestCreateFirmwareRT_IPListReferenceDoesNotExist(t *testing.T) {
 	}`
 
 	var template firmware.FirmwareRuleTemplate
-	json.Unmarshal([]byte(templateJSON), &template)
+	err := json.Unmarshal([]byte(templateJSON), &template)
+	assert.NilError(t, err)
 
 	result, err := createFirmwareRT(template)
 	assert.Assert(t, err != nil)

--- a/adminapi/queries/percentage_bean_service.go
+++ b/adminapi/queries/percentage_bean_service.go
@@ -352,7 +352,7 @@ func validatePercentageBeanReferences(bean *coreef.PercentageBean) error {
 		}
 		err = RunGlobalValidation(*bean.OptionalConditions, GetFeatureRuleAllowedOperations)
 		if err != nil {
-			return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, bean.Name+": "+err.Error())
+			return err
 		}
 	}
 

--- a/adminapi/queries/percentage_bean_service.go
+++ b/adminapi/queries/percentage_bean_service.go
@@ -342,7 +342,7 @@ func validatePercentageBeanReferences(bean *coreef.PercentageBean) error {
 	}
 
 	if !xutil.IsBlank(bean.Whitelist) && GetNamespacedListByIdAndType(bean.Whitelist, shared.IP_LIST) == nil {
-		return fmt.Errorf("IP list does not exist: %s", bean.Whitelist)
+		return fmt.Errorf("IP address list does not exist: %s", bean.Whitelist)
 	}
 
 	if bean.OptionalConditions != nil && len(re.ToConditions(bean.OptionalConditions)) > 0 {
@@ -352,7 +352,7 @@ func validatePercentageBeanReferences(bean *coreef.PercentageBean) error {
 		}
 		err = RunGlobalValidation(*bean.OptionalConditions, GetFeatureRuleAllowedOperations)
 		if err != nil {
-			return err
+			return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, bean.Name+": "+err.Error())
 		}
 	}
 

--- a/adminapi/queries/percentage_bean_service.go
+++ b/adminapi/queries/percentage_bean_service.go
@@ -234,7 +234,7 @@ func CreatePercentageBean(bean *coreef.PercentageBean, applicationType string, f
 	}
 
 	if err := validatePercentageBeanReferences(bean); err != nil {
-		return xwhttp.NewResponseEntity(http.StatusBadRequest, fmt.Errorf("%s : %s", bean.Name, err.Error()), nil)
+		return xwhttp.NewResponseEntity(http.StatusBadRequest, fmt.Errorf("%s: %s", bean.Name, err.Error()), nil)
 	}
 
 	if err := firmware.ValidateRuleName(bean.ID, bean.Name, applicationType); err != nil {
@@ -284,7 +284,7 @@ func UpdatePercentageBean(bean *coreef.PercentageBean, applicationType string, f
 	}
 
 	if err := validatePercentageBeanReferences(bean); err != nil {
-		return xwhttp.NewResponseEntity(http.StatusBadRequest, fmt.Errorf("%s : %s", bean.Name, err.Error()), nil)
+		return xwhttp.NewResponseEntity(http.StatusBadRequest, fmt.Errorf("%s: %s", bean.Name, err.Error()), nil)
 	}
 
 	if err := firmware.ValidateRuleName(bean.ID, bean.Name, applicationType); err != nil {

--- a/adminapi/queries/percentage_bean_service.go
+++ b/adminapi/queries/percentage_bean_service.go
@@ -234,7 +234,7 @@ func CreatePercentageBean(bean *coreef.PercentageBean, applicationType string, f
 	}
 
 	if err := validatePercentageBeanReferences(bean); err != nil {
-		return xwhttp.NewResponseEntity(http.StatusBadRequest, err, nil)
+		return xwhttp.NewResponseEntity(http.StatusBadRequest, fmt.Errorf("%s : %s", bean.Name, err.Error()), nil)
 	}
 
 	if err := firmware.ValidateRuleName(bean.ID, bean.Name, applicationType); err != nil {
@@ -284,7 +284,7 @@ func UpdatePercentageBean(bean *coreef.PercentageBean, applicationType string, f
 	}
 
 	if err := validatePercentageBeanReferences(bean); err != nil {
-		return xwhttp.NewResponseEntity(http.StatusBadRequest, err, nil)
+		return xwhttp.NewResponseEntity(http.StatusBadRequest, fmt.Errorf("%s : %s", bean.Name, err.Error()), nil)
 	}
 
 	if err := firmware.ValidateRuleName(bean.ID, bean.Name, applicationType); err != nil {
@@ -338,11 +338,11 @@ func validatePercentageBeanReferences(bean *coreef.PercentageBean) error {
 	}
 	normalizedModel := strings.ToUpper(strings.TrimSpace(bean.Model))
 	if !common.IsExistModel(normalizedModel) {
-		return fmt.Errorf("Model: %s does not exist", normalizedModel)
+		return fmt.Errorf("Model does not exist: %s", normalizedModel)
 	}
 
 	if !xutil.IsBlank(bean.Whitelist) && GetNamespacedListByIdAndType(bean.Whitelist, shared.IP_LIST) == nil {
-		return fmt.Errorf("IP address list '%s' does not exist", bean.Whitelist)
+		return fmt.Errorf("IP list does not exist: %s", bean.Whitelist)
 	}
 
 	if bean.OptionalConditions != nil && len(re.ToConditions(bean.OptionalConditions)) > 0 {

--- a/adminapi/setting/setting_rule_service.go
+++ b/adminapi/setting/setting_rule_service.go
@@ -160,7 +160,7 @@ func validateSettingRule(r *http.Request, entity *logupload.SettingRule) error {
 		return err
 	}
 	if err := queries.RunGlobalValidation(entity.Rule, queries.GetAllowedOperations); err != nil {
-		return err
+		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, entity.Name+": "+err.Error())
 	}
 	return nil
 }

--- a/adminapi/telemetry/telemetry_rule_service.go
+++ b/adminapi/telemetry/telemetry_rule_service.go
@@ -112,7 +112,7 @@ func telemetryRuleValidate(tmrule *xwlogupload.TelemetryRule) *xwhttp.ResponseEn
 	}
 	err = queries.RunGlobalValidation(*tmrule.GetRule(), queries.GetAllowedOperations)
 	if err != nil {
-		return xwhttp.NewResponseEntity(http.StatusBadRequest, err, nil)
+		return xwhttp.NewResponseEntity(http.StatusBadRequest, fmt.Errorf("%s: %s", tmrule.Name, err.Error()), nil)
 	}
 	tmrules := xwlogupload.GetTelemetryRuleListForAs()
 	for _, extmrule := range tmrules {

--- a/adminapi/telemetry/telemetry_v2_rule_service.go
+++ b/adminapi/telemetry/telemetry_v2_rule_service.go
@@ -277,7 +277,7 @@ func Create(entity *xwlogupload.TelemetryTwoRule, writeApplication string) error
 	}
 	err = queries.RunGlobalValidation(*entity.GetRule(), queries.GetAllowedOperations)
 	if err != nil {
-		return err
+		return fmt.Errorf("%s: %s", entity.Name, err.Error())
 	}
 	return xlogupload.SetOneTelemetryTwoRule(entity.ID, entity)
 }
@@ -293,7 +293,7 @@ func Update(entity *xwlogupload.TelemetryTwoRule, writeApplication string) error
 	}
 	err = queries.RunGlobalValidation(*entity.GetRule(), queries.GetAllowedOperations)
 	if err != nil {
-		return err
+		return fmt.Errorf("%s: %s", entity.Name, err.Error())
 	}
 	return xlogupload.SetOneTelemetryTwoRule(entity.ID, entity)
 }

--- a/adminapi/telemetry/telemetry_v2_rule_service.go
+++ b/adminapi/telemetry/telemetry_v2_rule_service.go
@@ -277,7 +277,7 @@ func Create(entity *xwlogupload.TelemetryTwoRule, writeApplication string) error
 	}
 	err = queries.RunGlobalValidation(*entity.GetRule(), queries.GetAllowedOperations)
 	if err != nil {
-		return fmt.Errorf("%s: %s", entity.Name, err.Error())
+		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, entity.Name+": "+err.Error())
 	}
 	return xlogupload.SetOneTelemetryTwoRule(entity.ID, entity)
 }
@@ -293,7 +293,7 @@ func Update(entity *xwlogupload.TelemetryTwoRule, writeApplication string) error
 	}
 	err = queries.RunGlobalValidation(*entity.GetRule(), queries.GetAllowedOperations)
 	if err != nil {
-		return fmt.Errorf("%s: %s", entity.Name, err.Error())
+		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, entity.Name+": "+err.Error())
 	}
 	return xlogupload.SetOneTelemetryTwoRule(entity.ID, entity)
 }


### PR DESCRIPTION
## Summary
This PR improves validation behavior and error consistency for rule/template flows.

- Added existence validation for firmware rule template conditions that reference:
  - `MODEL` with `IS`
  - `IP_ADDRESS` with `IN_LIST`
- Reused existing validation logic (`checkFixedArgValue`) instead of introducing new validators.
- Standardized `RunGlobalValidation`-related error responses to include entity name context (pattern: `EntityName: <validation error>`).
- Updated firmware rule template validation wrapping to return `NewRemoteErrorAS` with prefixed context.

## Why
Previously, firmware rule templates could accept references to non-existent model/IP list values, and some validation errors lacked entity-level context. This made troubleshooting harder and created inconsistent API error messaging across services.

## Scope of Changes
- Firmware rule template validation:
  - Enforced model/IP list reference checks during create/update validation path.
- Error message consistency updates across services using global rule validation patterns.
- Added/updated tests for missing model and missing IP list reference scenarios in firmware rule template tests.