### PR TITLE
Cherrypick model and ipaddress validation

### DIFF
--- a/adminapi/dcm/dcmformula_service.go
+++ b/adminapi/dcm/dcmformula_service.go
@@ -162,7 +162,7 @@ func dcmRuleValidate(dfrule *logupload.DCMGenericRule) *xwhttp.ResponseEntity {
 	}
 	err = queries.RunGlobalValidation(*dfrule.GetRule(), queries.GetFirmwareRuleAllowedOperations)
 	if err != nil {
-		return xwhttp.NewResponseEntity(http.StatusBadRequest, err, nil)
+		return xwhttp.NewResponseEntity(http.StatusBadRequest, fmt.Errorf("%s: %s", dfrule.Name, err.Error()), nil)
 	}
 	err = validatePercentage(dfrule)
 	if err != nil {

--- a/adminapi/queries/baserule_validator.go
+++ b/adminapi/queries/baserule_validator.go
@@ -206,7 +206,7 @@ func checkFixedArgValue(condition re.Condition, fp func(string) bool) error {
 		freeArgName := condition.GetFreeArg().GetName()
 		if freeArgName == xwcommon.MODEL || freeArgName == logupload.Model {
 			normalizedModel := strings.ToUpper(strings.TrimSpace(fixedArgValue))
-			if !xcommon.IsExistModel(normalizedModel) {
+			if !IsExistModel(normalizedModel) {
 				return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "Model does not exist: "+normalizedModel)
 			}
 		}

--- a/adminapi/queries/baserule_validator.go
+++ b/adminapi/queries/baserule_validator.go
@@ -187,7 +187,7 @@ func checkFixedArgValue(condition re.Condition, fp func(string) bool) error {
 		if !condition.GetFixedArg().IsStringValue() {
 			return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "FixedArg for IN_LIST operation must be a string value")
 		}
-		fixedArgValue := condition.GetFixedArg().GetValue().(string)
+		fixedArgValue := strings.TrimSpace(condition.GetFixedArg().GetValue().(string))
 		freeArgName := condition.GetFreeArg().GetName()
 		if freeArgName == xwcommon.IP_ADDRESS || freeArgName == logupload.EstbIp {
 			if GetNamespacedListByIdAndType(fixedArgValue, shared.IP_LIST) == nil {
@@ -198,7 +198,7 @@ func checkFixedArgValue(condition re.Condition, fp func(string) bool) error {
 		if !condition.GetFixedArg().IsStringValue() {
 			return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "FixedArg for IS operation must be a string value")
 		}
-		fixedArgValue := condition.GetFixedArg().GetValue().(string)
+		fixedArgValue := strings.TrimSpace(condition.GetFixedArg().GetValue().(string))
 		//fixedArgValue := coreef.trimSingleQuote (condition.GetFixedArg().String())
 		if !fp(fixedArgValue) {
 			return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, condition.FreeArg.GetName()+" is invalid: "+fixedArgValue)

--- a/adminapi/queries/baserule_validator.go
+++ b/adminapi/queries/baserule_validator.go
@@ -184,6 +184,9 @@ func checkFixedArgValue(condition re.Condition, fp func(string) bool) error {
 			}
 		}
 	} else if re.StandardOperationInList == operation {
+		if !condition.GetFixedArg().IsStringValue() {
+			return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "FixedArg for IN_LIST operation must be a string value")
+		}
 		fixedArgValue := condition.GetFixedArg().GetValue().(string)
 		freeArgName := condition.GetFreeArg().GetName()
 		if freeArgName == xwcommon.IP_ADDRESS || freeArgName == logupload.EstbIp {
@@ -192,6 +195,9 @@ func checkFixedArgValue(condition re.Condition, fp func(string) bool) error {
 			}
 		}
 	} else if re.StandardOperationIs == operation {
+		if !condition.GetFixedArg().IsStringValue() {
+			return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "FixedArg for IS operation must be a string value")
+		}
 		fixedArgValue := condition.GetFixedArg().GetValue().(string)
 		//fixedArgValue := coreef.trimSingleQuote (condition.GetFixedArg().String())
 		if !fp(fixedArgValue) {
@@ -238,6 +244,9 @@ func checkPercentOperation(condition re.Condition) (bool, error) {
 }
 
 func checkLikeOperation(condition re.Condition) error {
+	if !condition.GetFixedArg().IsStringValue() {
+		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "FixedArg for LIKE operation must be a string value")
+	}
 	_, err := regexp.Compile(condition.GetFixedArg().GetValue().(string))
 	// _, err := regexp.Compile(coreef.trimSingleQuote (condition.GetFixedArg().String()))
 	return err

--- a/adminapi/queries/baserule_validator.go
+++ b/adminapi/queries/baserule_validator.go
@@ -183,11 +183,26 @@ func checkFixedArgValue(condition re.Condition, fp func(string) bool) error {
 				return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "Incorrect Collection Value")
 			}
 		}
+	} else if re.StandardOperationInList == operation {
+		fixedArgValue := condition.GetFixedArg().GetValue().(string)
+		freeArgName := condition.GetFreeArg().GetName()
+		if freeArgName == xwcommon.IP_ADDRESS || freeArgName == logupload.EstbIp {
+			if GetNamespacedListByIdAndType(fixedArgValue, shared.IP_LIST) == nil {
+				return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "IP list does not exist: "+fixedArgValue)
+			}
+		}
 	} else if re.StandardOperationIs == operation {
 		fixedArgValue := condition.GetFixedArg().GetValue().(string)
 		//fixedArgValue := coreef.trimSingleQuote (condition.GetFixedArg().String())
 		if !fp(fixedArgValue) {
 			return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, condition.FreeArg.GetName()+" is invalid: "+fixedArgValue)
+		}
+		freeArgName := condition.GetFreeArg().GetName()
+		if freeArgName == xwcommon.MODEL || freeArgName == logupload.Model {
+			normalizedModel := strings.ToUpper(strings.TrimSpace(fixedArgValue))
+			if !xcommon.IsExistModel(normalizedModel) {
+				return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "Model does not exist: "+normalizedModel)
+			}
 		}
 	} else if re.StandardOperationPercent == operation {
 		ret, err := checkPercentOperation(condition)

--- a/adminapi/queries/baserule_validator_test.go
+++ b/adminapi/queries/baserule_validator_test.go
@@ -23,7 +23,10 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	xcommon "github.com/rdkcentral/xconfadmin/common"
+	xwcommon "github.com/rdkcentral/xconfwebconfig/common"
 	re "github.com/rdkcentral/xconfwebconfig/rulesengine"
+	"github.com/rdkcentral/xconfwebconfig/shared"
+	logupload "github.com/rdkcentral/xconfwebconfig/shared/logupload"
 )
 
 func TestEqualFreeArgNames_Equal(t *testing.T) {
@@ -1272,4 +1275,125 @@ func TestRunGlobalValidation_InvalidOperation(t *testing.T) {
 
 	err := RunGlobalValidation(rule, GetAllowedOperations)
 	assert.Error(t, err)
+}
+
+// Tests for new validation logic - IN_LIST operation on IP_ADDRESS field
+
+func TestCheckFixedArgValue_InListOperationOnIPAddress_MissingIPList(t *testing.T) {
+	condition := re.Condition{
+		FreeArg:   &re.FreeArg{Name: xwcommon.IP_ADDRESS},
+		Operation: re.StandardOperationInList,
+		FixedArg:  re.NewFixedArg("NONEXISTENT_IP_LIST"),
+	}
+
+	err := checkFixedArgValue(condition, isNotBlank)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "IP list does not exist")
+}
+
+func TestCheckFixedArgValue_InListOperationOnIPAddress_ValidIPList(t *testing.T) {
+	SkipIfMockDatabase(t) // Service test uses ds.GetCachedSimpleDao() directly
+	DeleteAllEntities()
+
+	// Create a valid IP list using the package-level helper and service function
+	ipList := makeGenericList("TEST_IP_LIST", shared.IP_LIST, []string{"192.168.1.0/24"})
+	CreateNamespacedList(ipList, false)
+
+	condition := re.Condition{
+		FreeArg:   &re.FreeArg{Name: xwcommon.IP_ADDRESS},
+		Operation: re.StandardOperationInList,
+		FixedArg:  re.NewFixedArg("TEST_IP_LIST"),
+	}
+
+	err := checkFixedArgValue(condition, isNotBlank)
+	assert.NoError(t, err)
+
+	DeleteAllEntities()
+}
+
+func TestCheckFixedArgValue_InListOperationOnEstbIp_MissingIPList(t *testing.T) {
+	condition := re.Condition{
+		FreeArg:   &re.FreeArg{Name: logupload.EstbIp},
+		Operation: re.StandardOperationInList,
+		FixedArg:  re.NewFixedArg("MISSING_LIST_ID"),
+	}
+
+	err := checkFixedArgValue(condition, isNotBlank)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "IP list does not exist")
+}
+
+func TestCheckFixedArgValue_InListOperationOnNonIPField_NoListValidation(t *testing.T) {
+	// For non-IP fields, IN_LIST should not validate IP list existence
+	condition := re.Condition{
+		FreeArg:   &re.FreeArg{Name: "model"},
+		Operation: re.StandardOperationInList,
+		FixedArg:  re.NewFixedArg("ANYTHING"),
+	}
+
+	// Non-IP field: no IP list validation should occur
+	err := checkFixedArgValue(condition, isNotBlank)
+	assert.NoError(t, err)
+}
+
+// Tests for new validation logic - IS operation on MODEL field
+
+func TestCheckFixedArgValue_IsOperationOnModel_MissingModel(t *testing.T) {
+	condition := re.Condition{
+		FreeArg:   &re.FreeArg{Name: xwcommon.MODEL},
+		Operation: re.StandardOperationIs,
+		FixedArg:  re.NewFixedArg("NONEXISTENT_MODEL_XYZ_123"),
+	}
+
+	err := checkFixedArgValue(condition, isNotBlank)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Model does not exist")
+}
+
+func TestCheckFixedArgValue_IsOperationOnModel_ValidModel(t *testing.T) {
+	SkipIfMockDatabase(t) // Service test uses ds.GetCachedSimpleDao() directly
+	DeleteAllEntities()
+
+	// Create a valid model using the service function
+	model := &shared.Model{
+		ID:          "TEST_MODEL",
+		Description: "Test Model",
+	}
+	CreateModel(model)
+
+	condition := re.Condition{
+		FreeArg:   &re.FreeArg{Name: xwcommon.MODEL},
+		Operation: re.StandardOperationIs,
+		FixedArg:  re.NewFixedArg("TEST_MODEL"),
+	}
+
+	err := checkFixedArgValue(condition, isNotBlank)
+	assert.NoError(t, err)
+
+	DeleteAllEntities()
+}
+
+func TestCheckFixedArgValue_IsOperationOnLoguploadModel_MissingModel(t *testing.T) {
+	condition := re.Condition{
+		FreeArg:   &re.FreeArg{Name: logupload.Model},
+		Operation: re.StandardOperationIs,
+		FixedArg:  re.NewFixedArg("MISSING_MODEL_ID"),
+	}
+
+	err := checkFixedArgValue(condition, isNotBlank)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Model does not exist")
+}
+
+func TestCheckFixedArgValue_IsOperationOnNonModelField_NoModelValidation(t *testing.T) {
+	// For non-MODEL fields, IS should not validate model existence
+	condition := re.Condition{
+		FreeArg:   &re.FreeArg{Name: "environment"},
+		Operation: re.StandardOperationIs,
+		FixedArg:  re.NewFixedArg("ANYTHING"),
+	}
+
+	// Non-MODEL field: no model validation should occur
+	err := checkFixedArgValue(condition, isNotBlank)
+	assert.NoError(t, err)
 }

--- a/adminapi/queries/feature_rule_service.go
+++ b/adminapi/queries/feature_rule_service.go
@@ -255,7 +255,7 @@ func ValidateFeatureRule(featureRule *rfc.FeatureRule, applicationType string) e
 	}
 	err = RunGlobalValidation(*featureRule.Rule, GetFeatureRuleAllowedOperations)
 	if err != nil {
-		return err
+		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, featureRule.Name+": "+err.Error())
 	}
 	if featureRule.Name == "" {
 		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "FeatureRule name is blank")

--- a/adminapi/queries/feature_rule_service.go
+++ b/adminapi/queries/feature_rule_service.go
@@ -249,6 +249,9 @@ func ValidateFeatureRule(featureRule *rfc.FeatureRule, applicationType string) e
 	if featureRule.Rule == nil {
 		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "Rule is empty")
 	}
+	if featureRule.Name == "" {
+		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "FeatureRule name is blank")
+	}
 	err := ValidateRuleStructure(featureRule.Rule)
 	if err != nil {
 		return err
@@ -256,9 +259,6 @@ func ValidateFeatureRule(featureRule *rfc.FeatureRule, applicationType string) e
 	err = RunGlobalValidation(*featureRule.Rule, GetFeatureRuleAllowedOperations)
 	if err != nil {
 		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, featureRule.Name+": "+err.Error())
-	}
-	if featureRule.Name == "" {
-		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "FeatureRule name is blank")
 	}
 	if len(featureRule.FeatureIds) < 1 {
 		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "Features should be specified")

--- a/adminapi/queries/firmware_rule_template_service.go
+++ b/adminapi/queries/firmware_rule_template_service.go
@@ -190,8 +190,34 @@ func validateRule(fr *re.Rule, action *corefw.TemplateApplicableAction) error {
 		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "FirmwareRuleTemplate "+fr.Id()+" should have a minimum one condition")
 	}
 	for _, c := range conditions {
+		if c == nil {
+			return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "Condition is null")
+		}
+		if err := checkConditionNullsOrBlanks(*c); err != nil {
+			return err
+		}
+		if err := checkDuplicateFixedArgListItems(*c); err != nil {
+			return err
+		}
 		if err := checkOperationName(c, GetFirmwareRuleAllowedOperations); err != nil {
 			return err
+		}
+		if (equalOperations(c.GetOperation(), re.StandardOperationIs) && c.GetFreeArg().GetName() == xwcommon.MODEL) ||
+			(equalOperations(c.GetOperation(), re.StandardOperationInList) && c.GetFreeArg().GetName() == xwcommon.IP_ADDRESS) {
+			if _, ok := c.GetFixedArg().GetValue().(string); !ok {
+				return xwcommon.NewRemoteErrorAS(
+					http.StatusBadRequest,
+					fmt.Sprintf(
+						"FixedArg value should be string for freeArg '%s' with operation '%s', got %T",
+						c.GetFreeArg().GetName(),
+						c.GetOperation(),
+						c.GetFixedArg().GetValue(),
+					),
+				)
+			}
+			if err := checkFixedArgValue(*c, isNotBlank); err != nil {
+				return err
+			}
 		}
 	}
 	return validateProperties(action)

--- a/adminapi/queries/firmware_rule_template_service_test.go
+++ b/adminapi/queries/firmware_rule_template_service_test.go
@@ -372,6 +372,80 @@ func TestCreateFirmwareRT_ValidationError(t *testing.T) {
 	assert.ErrorContains(t, err, "Missing applicable action type")
 }
 
+func TestCreateFirmwareRT_ModelReferenceDoesNotExist(t *testing.T) {
+	DeleteAllEntities()
+	setupTestModels()
+	defer DeleteAllEntities()
+
+	templateJSON := `{
+		"id": "` + uuid.New().String() + `",
+		"name": "MissingModelRef",
+		"priority": 1,
+		"editable": true,
+		"rule": {
+			"condition": {
+				"freeArg": {"type": "STRING", "name": "model"},
+				"operation": "IS",
+				"fixedArg": {
+					"bean": {
+						"value": {"java.lang.String": "NON_EXISTENT_MODEL_FOR_FRT"}
+					}
+				}
+			}
+		},
+		"applicableAction": {
+			"type": ".RuleAction",
+			"actionType": "RULE_TEMPLATE"
+		}
+	}`
+
+	var template firmware.FirmwareRuleTemplate
+	err := json.Unmarshal([]byte(templateJSON), &template)
+	assert.NilError(t, err)
+
+	result, err := createFirmwareRT(template)
+	assert.Assert(t, err != nil)
+	assert.Assert(t, result == nil)
+	assert.ErrorContains(t, err, "Model does not exist")
+}
+
+func TestCreateFirmwareRT_IPListReferenceDoesNotExist(t *testing.T) {
+	DeleteAllEntities()
+	setupTestModels()
+	defer DeleteAllEntities()
+
+	templateJSON := `{
+		"id": "` + uuid.New().String() + `",
+		"name": "MissingIPListRef",
+		"priority": 1,
+		"editable": true,
+		"rule": {
+			"condition": {
+				"freeArg": {"type": "STRING", "name": "ipAddress"},
+				"operation": "IN_LIST",
+				"fixedArg": {
+					"bean": {
+						"value": {"java.lang.String": "NON_EXISTENT_IP_LIST_FOR_FRT"}
+					}
+				}
+			}
+		},
+		"applicableAction": {
+			"type": ".RuleAction",
+			"actionType": "RULE_TEMPLATE"
+		}
+	}`
+
+	var template firmware.FirmwareRuleTemplate
+	err := json.Unmarshal([]byte(templateJSON), &template)
+	assert.NilError(t, err)
+
+	result, err := createFirmwareRT(template)
+	assert.Assert(t, err != nil)
+	assert.Assert(t, result == nil)
+	assert.ErrorContains(t, err, "IP list does not exist")
+}
+
 func TestCreateFirmwareRT_DuplicateName(t *testing.T) {
 	DeleteAllEntities()
 	setupTestModels()

--- a/adminapi/queries/percentage_bean_service.go
+++ b/adminapi/queries/percentage_bean_service.go
@@ -38,7 +38,6 @@ import (
 	xwcommon "github.com/rdkcentral/xconfwebconfig/common"
 	xwhttp "github.com/rdkcentral/xconfwebconfig/http"
 	re "github.com/rdkcentral/xconfwebconfig/rulesengine"
-	ru "github.com/rdkcentral/xconfwebconfig/rulesengine"
 	"github.com/rdkcentral/xconfwebconfig/shared"
 	coreef "github.com/rdkcentral/xconfwebconfig/shared/estbfirmware"
 	"github.com/rdkcentral/xconfwebconfig/shared/firmware"
@@ -234,6 +233,10 @@ func CreatePercentageBean(bean *coreef.PercentageBean, applicationType string, f
 		return xwhttp.NewResponseEntity(http.StatusConflict, fmt.Errorf("Entity with id %s ApplicationType doesn't match", bean.ID), nil)
 	}
 
+	if err := validatePercentageBeanReferences(bean); err != nil {
+		return xwhttp.NewResponseEntity(http.StatusBadRequest, err, nil)
+	}
+
 	if err := firmware.ValidateRuleName(bean.ID, bean.Name, applicationType); err != nil {
 		return xwhttp.NewResponseEntity(http.StatusBadRequest, err, nil)
 	}
@@ -254,7 +257,7 @@ func CreatePercentageBean(bean *coreef.PercentageBean, applicationType string, f
 	firmware.SortConfigEntry(bean.Distributions)
 
 	fRule := coreef.ConvertPercentageBeanToFirmwareRule(*bean)
-	ru.NormalizeConditions(&fRule.Rule)
+	re.NormalizeConditions(&fRule.Rule)
 	if err := firmware.CreateFirmwareRuleOneDB(fRule); err != nil {
 		return xwhttp.NewResponseEntity(http.StatusInternalServerError, err, nil)
 	}
@@ -280,6 +283,10 @@ func UpdatePercentageBean(bean *coreef.PercentageBean, applicationType string, f
 		return xwhttp.NewResponseEntity(http.StatusBadRequest, fmt.Errorf("ApplicationType cannot be changed: Existing value: %s New Value: %s", fRule.ApplicationType, bean.ApplicationType), nil)
 	}
 
+	if err := validatePercentageBeanReferences(bean); err != nil {
+		return xwhttp.NewResponseEntity(http.StatusBadRequest, err, nil)
+	}
+
 	if err := firmware.ValidateRuleName(bean.ID, bean.Name, applicationType); err != nil {
 		return xwhttp.NewResponseEntity(http.StatusBadRequest, err, nil)
 	}
@@ -300,7 +307,7 @@ func UpdatePercentageBean(bean *coreef.PercentageBean, applicationType string, f
 	firmware.SortConfigEntry(bean.Distributions)
 
 	newRule := coreef.ConvertPercentageBeanToFirmwareRule(*bean)
-	ru.NormalizeConditions(&newRule.Rule)
+	re.NormalizeConditions(&newRule.Rule)
 	if err := firmware.CreateFirmwareRuleOneDB(newRule); err != nil {
 		return xwhttp.NewResponseEntity(http.StatusInternalServerError, err, nil)
 	}
@@ -323,6 +330,33 @@ func DeletePercentageBean(id string, app string) *xwhttp.ResponseEntity {
 	}
 
 	return xwhttp.NewResponseEntity(http.StatusNoContent, nil, nil)
+}
+
+func validatePercentageBeanReferences(bean *coreef.PercentageBean) error {
+	if xutil.IsBlank(bean.Model) {
+		return errors.New("Model is empty")
+	}
+	normalizedModel := strings.ToUpper(strings.TrimSpace(bean.Model))
+	if !common.IsExistModel(normalizedModel) {
+		return fmt.Errorf("Model: %s does not exist", normalizedModel)
+	}
+
+	if !xutil.IsBlank(bean.Whitelist) && GetNamespacedListByIdAndType(bean.Whitelist, shared.IP_LIST) == nil {
+		return fmt.Errorf("IP address list '%s' does not exist", bean.Whitelist)
+	}
+
+	if bean.OptionalConditions != nil && len(re.ToConditions(bean.OptionalConditions)) > 0 {
+		err := ValidateRuleStructure(bean.OptionalConditions)
+		if err != nil {
+			return err
+		}
+		err = RunGlobalValidation(*bean.OptionalConditions, GetFeatureRuleAllowedOperations)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func createCanaries(newBean *coreef.PercentageBean, oldRule *firmware.FirmwareRule, fields log.Fields) {

--- a/adminapi/queries/percentage_bean_service.go
+++ b/adminapi/queries/percentage_bean_service.go
@@ -34,7 +34,6 @@ import (
 	xshared "github.com/rdkcentral/xconfadmin/shared"
 	"github.com/rdkcentral/xconfadmin/util"
 
-	xcommon "github.com/rdkcentral/xconfwebconfig/common"
 	xwcommon "github.com/rdkcentral/xconfwebconfig/common"
 	xwhttp "github.com/rdkcentral/xconfwebconfig/http"
 	re "github.com/rdkcentral/xconfwebconfig/rulesengine"
@@ -723,7 +722,7 @@ func PercentageBeanFilterByContext(searchContext map[string]string, applicationT
 			}
 		}
 
-		if model, ok := util.FindEntryInContext(searchContext, xcommon.MODEL, false); ok {
+		if model, ok := util.FindEntryInContext(searchContext, common.MODEL, false); ok {
 			if !strings.Contains(strings.ToLower(pbRule.Model), strings.ToLower(model)) {
 				continue
 			}

--- a/adminapi/queries/percentage_bean_service.go
+++ b/adminapi/queries/percentage_bean_service.go
@@ -341,8 +341,9 @@ func validatePercentageBeanReferences(bean *coreef.PercentageBean) error {
 		return fmt.Errorf("Model does not exist: %s", normalizedModel)
 	}
 
-	if !xutil.IsBlank(bean.Whitelist) && GetNamespacedListByIdAndType(bean.Whitelist, shared.IP_LIST) == nil {
-		return fmt.Errorf("IP address list does not exist: %s", bean.Whitelist)
+	normalizedWhitelist := strings.TrimSpace(bean.Whitelist)
+	if normalizedWhitelist != "" && GetNamespacedListByIdAndType(normalizedWhitelist, shared.IP_LIST) == nil {
+		return fmt.Errorf("IP address list does not exist: %s", normalizedWhitelist)
 	}
 
 	if bean.OptionalConditions != nil && len(re.ToConditions(bean.OptionalConditions)) > 0 {

--- a/adminapi/queries/percentage_bean_service.go
+++ b/adminapi/queries/percentage_bean_service.go
@@ -337,7 +337,7 @@ func validatePercentageBeanReferences(bean *coreef.PercentageBean) error {
 		return errors.New("Model is empty")
 	}
 	normalizedModel := strings.ToUpper(strings.TrimSpace(bean.Model))
-	if !common.IsExistModel(normalizedModel) {
+	if !IsExistModel(normalizedModel) {
 		return fmt.Errorf("Model does not exist: %s", normalizedModel)
 	}
 

--- a/adminapi/queries/percentage_bean_service.go
+++ b/adminapi/queries/percentage_bean_service.go
@@ -234,7 +234,7 @@ func CreatePercentageBean(bean *coreef.PercentageBean, applicationType string, f
 	}
 
 	if err := validatePercentageBeanReferences(bean); err != nil {
-		return xwhttp.NewResponseEntity(http.StatusBadRequest, err, nil)
+		return xwhttp.NewResponseEntity(http.StatusBadRequest, fmt.Errorf("%s: %s", bean.Name, err.Error()), nil)
 	}
 
 	if err := firmware.ValidateRuleName(bean.ID, bean.Name, applicationType); err != nil {
@@ -284,7 +284,7 @@ func UpdatePercentageBean(bean *coreef.PercentageBean, applicationType string, f
 	}
 
 	if err := validatePercentageBeanReferences(bean); err != nil {
-		return xwhttp.NewResponseEntity(http.StatusBadRequest, err, nil)
+		return xwhttp.NewResponseEntity(http.StatusBadRequest, fmt.Errorf("%s: %s", bean.Name, err.Error()), nil)
 	}
 
 	if err := firmware.ValidateRuleName(bean.ID, bean.Name, applicationType); err != nil {
@@ -338,11 +338,11 @@ func validatePercentageBeanReferences(bean *coreef.PercentageBean) error {
 	}
 	normalizedModel := strings.ToUpper(strings.TrimSpace(bean.Model))
 	if !common.IsExistModel(normalizedModel) {
-		return fmt.Errorf("Model: %s does not exist", normalizedModel)
+		return fmt.Errorf("Model does not exist: %s", normalizedModel)
 	}
 
 	if !xutil.IsBlank(bean.Whitelist) && GetNamespacedListByIdAndType(bean.Whitelist, shared.IP_LIST) == nil {
-		return fmt.Errorf("IP address list '%s' does not exist", bean.Whitelist)
+		return fmt.Errorf("IP address list does not exist: %s", bean.Whitelist)
 	}
 
 	if bean.OptionalConditions != nil && len(re.ToConditions(bean.OptionalConditions)) > 0 {

--- a/adminapi/queries/percentage_bean_service.go
+++ b/adminapi/queries/percentage_bean_service.go
@@ -233,12 +233,12 @@ func CreatePercentageBean(bean *coreef.PercentageBean, applicationType string, f
 		return xwhttp.NewResponseEntity(http.StatusConflict, fmt.Errorf("Entity with id %s ApplicationType doesn't match", bean.ID), nil)
 	}
 
-	if err := validatePercentageBeanReferences(bean); err != nil {
-		return xwhttp.NewResponseEntity(http.StatusBadRequest, fmt.Errorf("%s: %s", bean.Name, err.Error()), nil)
-	}
-
 	if err := firmware.ValidateRuleName(bean.ID, bean.Name, applicationType); err != nil {
 		return xwhttp.NewResponseEntity(http.StatusBadRequest, err, nil)
+	}
+
+	if err := validatePercentageBeanReferences(bean); err != nil {
+		return xwhttp.NewResponseEntity(http.StatusBadRequest, fmt.Errorf("%s: %s", bean.Name, err.Error()), nil)
 	}
 
 	if err := bean.ValidateForAS(); err != nil {
@@ -283,12 +283,12 @@ func UpdatePercentageBean(bean *coreef.PercentageBean, applicationType string, f
 		return xwhttp.NewResponseEntity(http.StatusBadRequest, fmt.Errorf("ApplicationType cannot be changed: Existing value: %s New Value: %s", fRule.ApplicationType, bean.ApplicationType), nil)
 	}
 
-	if err := validatePercentageBeanReferences(bean); err != nil {
-		return xwhttp.NewResponseEntity(http.StatusBadRequest, fmt.Errorf("%s: %s", bean.Name, err.Error()), nil)
-	}
-
 	if err := firmware.ValidateRuleName(bean.ID, bean.Name, applicationType); err != nil {
 		return xwhttp.NewResponseEntity(http.StatusBadRequest, err, nil)
+	}
+
+	if err := validatePercentageBeanReferences(bean); err != nil {
+		return xwhttp.NewResponseEntity(http.StatusBadRequest, fmt.Errorf("%s: %s", bean.Name, err.Error()), nil)
 	}
 
 	if err := bean.ValidateForAS(); err != nil {

--- a/adminapi/queries/percentage_bean_service_test.go
+++ b/adminapi/queries/percentage_bean_service_test.go
@@ -25,6 +25,9 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
+	xwcommon "github.com/rdkcentral/xconfwebconfig/common"
+	re "github.com/rdkcentral/xconfwebconfig/rulesengine"
+	"github.com/rdkcentral/xconfwebconfig/shared"
 	coreef "github.com/rdkcentral/xconfwebconfig/shared/estbfirmware"
 )
 
@@ -539,4 +542,162 @@ func TestDeletePercentageBean_ResponseEntity_AppTypeMismatch(t *testing.T) {
 	assert.NotNil(t, response)
 	assert.Equal(t, http.StatusNotFound, response.Status)
 	assert.NotNil(t, response.Error)
+}
+
+// Tests for validatePercentageBeanReferences
+
+func TestValidatePercentageBeanReferences_InvalidModel(t *testing.T) {
+	DeleteAllEntities()
+
+	bean := &coreef.PercentageBean{
+		ID:              "test-bean-id",
+		Name:            "test-bean",
+		Model:           "NONEXISTENT_MODEL_XYZ",
+		ApplicationType: "stb",
+	}
+
+	err := validatePercentageBeanReferences(bean)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Model")
+	assert.Contains(t, err.Error(), "does not exist")
+}
+
+func TestValidatePercentageBeanReferences_ValidModel(t *testing.T) {
+	SkipIfMockDatabase(t) // Service test uses ds.GetCachedSimpleDao() directly
+	DeleteAllEntities()
+
+	// Create a valid model first
+	model := &shared.Model{
+		ID:          "TEST_MODEL",
+		Description: "Test Model",
+	}
+	CreateModel(model)
+
+	bean := &coreef.PercentageBean{
+		ID:              "test-bean-id",
+		Name:            "test-bean",
+		Model:           "TEST_MODEL",
+		ApplicationType: "stb",
+	}
+
+	err := validatePercentageBeanReferences(bean)
+	assert.NoError(t, err)
+
+	DeleteAllEntities()
+}
+
+func TestValidatePercentageBeanReferences_InvalidIPList(t *testing.T) {
+	SkipIfMockDatabase(t) // Service test uses ds.GetCachedSimpleDao() directly
+	DeleteAllEntities()
+
+	// Create a valid model first
+	model := &shared.Model{
+		ID:          "TEST_MODEL",
+		Description: "Test Model",
+	}
+	CreateModel(model)
+
+	bean := &coreef.PercentageBean{
+		ID:              "test-bean-id",
+		Name:            "test-bean",
+		Model:           "TEST_MODEL",
+		Whitelist:       "NONEXISTENT_IP_LIST",
+		ApplicationType: "stb",
+	}
+
+	err := validatePercentageBeanReferences(bean)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "IP address list")
+	assert.Contains(t, err.Error(), "does not exist")
+
+	DeleteAllEntities()
+}
+
+func TestValidatePercentageBeanReferences_ValidIPList(t *testing.T) {
+	SkipIfMockDatabase(t) // Service test uses ds.GetCachedSimpleDao() directly
+	DeleteAllEntities()
+
+	// Create a valid model
+	model := &shared.Model{
+		ID:          "TEST_MODEL",
+		Description: "Test Model",
+	}
+	CreateModel(model)
+
+	// Create a valid IP list
+	ipList := makeGenericList("TEST_IP_LIST", shared.IP_LIST, []string{"192.168.1.0/24"})
+	CreateNamespacedList(ipList, false)
+
+	bean := &coreef.PercentageBean{
+		ID:              "test-bean-id",
+		Name:            "test-bean",
+		Model:           "TEST_MODEL",
+		Whitelist:       "TEST_IP_LIST",
+		ApplicationType: "stb",
+	}
+
+	err := validatePercentageBeanReferences(bean)
+	assert.NoError(t, err)
+
+	DeleteAllEntities()
+}
+
+func TestValidatePercentageBeanReferences_BlankWhitelist(t *testing.T) {
+	SkipIfMockDatabase(t) // Service test uses ds.GetCachedSimpleDao() directly
+	DeleteAllEntities()
+
+	// Create a valid model
+	model := &shared.Model{
+		ID:          "TEST_MODEL",
+		Description: "Test Model",
+	}
+	CreateModel(model)
+
+	bean := &coreef.PercentageBean{
+		ID:              "test-bean-id",
+		Name:            "test-bean",
+		Model:           "TEST_MODEL",
+		Whitelist:       "", // Blank whitelist should be allowed
+		ApplicationType: "stb",
+	}
+
+	err := validatePercentageBeanReferences(bean)
+	assert.NoError(t, err)
+
+	DeleteAllEntities()
+}
+
+func TestValidatePercentageBeanReferences_InvalidOptionalConditions(t *testing.T) {
+	SkipIfMockDatabase(t) // Service test uses ds.GetCachedSimpleDao() directly
+	DeleteAllEntities()
+
+	// Create a valid model
+	model := &shared.Model{
+		ID:          "TEST_MODEL",
+		Description: "Test Model",
+	}
+	CreateModel(model)
+
+	// Create optional condition referencing a model that doesn't exist
+	optionalConditions := &re.Rule{
+		Condition: &re.Condition{
+			FreeArg:   &re.FreeArg{Name: xwcommon.MODEL},
+			Operation: re.StandardOperationIs,
+			FixedArg:  re.NewFixedArg("INVALID_MODEL"),
+		},
+	}
+
+	bean := &coreef.PercentageBean{
+		ID:                 "test-bean-id",
+		Name:               "test-bean",
+		Model:              "TEST_MODEL",
+		ApplicationType:    "stb",
+		OptionalConditions: optionalConditions,
+	}
+
+	err := validatePercentageBeanReferences(bean)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Model does not exist")
+
+	DeleteAllEntities()
 }

--- a/adminapi/setting/setting_rule_service.go
+++ b/adminapi/setting/setting_rule_service.go
@@ -160,7 +160,7 @@ func validateSettingRule(r *http.Request, entity *logupload.SettingRule) error {
 		return err
 	}
 	if err := queries.RunGlobalValidation(entity.Rule, queries.GetAllowedOperations); err != nil {
-		return err
+		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, entity.Name+": "+err.Error())
 	}
 	return nil
 }

--- a/adminapi/telemetry/telemetry_rule_service.go
+++ b/adminapi/telemetry/telemetry_rule_service.go
@@ -112,7 +112,7 @@ func telemetryRuleValidate(tmrule *xwlogupload.TelemetryRule) *xwhttp.ResponseEn
 	}
 	err = queries.RunGlobalValidation(*tmrule.GetRule(), queries.GetAllowedOperations)
 	if err != nil {
-		return xwhttp.NewResponseEntity(http.StatusBadRequest, err, nil)
+		return xwhttp.NewResponseEntity(http.StatusBadRequest, fmt.Errorf("%s: %s", tmrule.Name, err.Error()), nil)
 	}
 	tmrules := xwlogupload.GetTelemetryRuleListForAs()
 	for _, extmrule := range tmrules {

--- a/adminapi/telemetry/telemetry_v2_rule_service.go
+++ b/adminapi/telemetry/telemetry_v2_rule_service.go
@@ -277,7 +277,7 @@ func Create(entity *xwlogupload.TelemetryTwoRule, writeApplication string) error
 	}
 	err = queries.RunGlobalValidation(*entity.GetRule(), queries.GetAllowedOperations)
 	if err != nil {
-		return err
+		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, entity.Name+": "+err.Error())
 	}
 	return xlogupload.SetOneTelemetryTwoRule(entity.ID, entity)
 }
@@ -293,7 +293,7 @@ func Update(entity *xwlogupload.TelemetryTwoRule, writeApplication string) error
 	}
 	err = queries.RunGlobalValidation(*entity.GetRule(), queries.GetAllowedOperations)
 	if err != nil {
-		return err
+		return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, entity.Name+": "+err.Error())
 	}
 	return xlogupload.SetOneTelemetryTwoRule(entity.ID, entity)
 }


### PR DESCRIPTION
This pull request introduces comprehensive validation enhancements across several rule and configuration types, ensuring that references to models and IP lists are valid before allowing creation or updates. It also improves error messaging by including the entity name in validation errors, making issues easier to identify. Extensive unit tests have been added to verify these new validation behaviors.

**Validation improvements for references:**

* Added checks to ensure that referenced models exist when using the `IS` operation on `MODEL` fields and that referenced IP lists exist when using the `IN_LIST` operation on `IP_ADDRESS` or `EstbIp` fields in rules. If these references are missing or invalid, descriptive errors are returned. [[1]](diffhunk://#diff-0e4721e2f994640b11b6b4f8d32a0405898329560ff6a6656747b05f9248b81aR186-R206) [[2]](diffhunk://#diff-f7377e03624fb8e3e5655856cd59a541e7b57f7c63de4810131f097768753123R193-R221) [[3]](diffhunk://#diff-5d58817874ea81dff0a5f55a23b5117d82bd667dac51d4d7c65e4e0f1b1e6187R335-R361)
* Introduced the `validatePercentageBeanReferences` function to verify model and IP list existence in `PercentageBean` creation and updates, and applied this validation in the relevant service methods. [[1]](diffhunk://#diff-5d58817874ea81dff0a5f55a23b5117d82bd667dac51d4d7c65e4e0f1b1e6187R236-R239) [[2]](diffhunk://#diff-5d58817874ea81dff0a5f55a23b5117d82bd667dac51d4d7c65e4e0f1b1e6187R286-R289) [[3]](diffhunk://#diff-5d58817874ea81dff0a5f55a23b5117d82bd667dac51d4d7c65e4e0f1b1e6187R335-R361)

**Improved error messaging:**

* Updated error responses in rule validation functions to include the name of the entity (rule, feature rule, setting rule, telemetry rule, etc.) in the error message for easier debugging and traceability. [[1]](diffhunk://#diff-c7445159376f5a4bf532dc5483620a3eed06a0b1c0a1218b72cce05eb2d3c8daL165-R165) [[2]](diffhunk://#diff-052814efc29ade2be889ba90974ded692e045f9c0b169cac8464a7bba9c5acf9L258-R258) [[3]](diffhunk://#diff-37f3d95ad41252d7ad4090620a113bc0a0461c4e5ac8dc992ba0f1fa8179866cL163-R163) [[4]](diffhunk://#diff-cf6e497ec845b59cf2d7e01a25a21441dfa3826fce284d30f5061697ff3dc6dbL115-R115) [[5]](diffhunk://#diff-7964dda4a29b231098de83e123eadf8b0c1c877deff589f1644f39eb541e139eL280-R280) [[6]](diffhunk://#diff-5d58817874ea81dff0a5f55a23b5117d82bd667dac51d4d7c65e4e0f1b1e6187R236-R239) [[7]](diffhunk://#diff-5d58817874ea81dff0a5f55a23b5117d82bd667dac51d4d7c65e4e0f1b1e6187R286-R289)

**Unit tests for new validation logic:**

* Added extensive tests to cover scenarios where model or IP list references are missing or invalid in rules and beans, as well as cases where valid references are provided. This includes tests for both success and failure cases for the new validation logic. [[1]](diffhunk://#diff-a403412cd82aff5e31e86d91ccbe92327d53887348a1182895e4317e71a5a421R1279-R1399) [[2]](diffhunk://#diff-2f747e38ca7e0b9a39edc83d3f4f098ec0ca2c7663ae45969090baf22f83fd9bR375-R448) [[3]](diffhunk://#diff-c25f4c64c473e5c6fcb35519a6f9ef4918ff866b66508041b7a0b623aa90491dR546-R703)

**Code cleanup and consistency:**

* Standardized import usage and replaced a redundant import alias. [[1]](diffhunk://#diff-5d58817874ea81dff0a5f55a23b5117d82bd667dac51d4d7c65e4e0f1b1e6187L41) [[2]](diffhunk://#diff-c25f4c64c473e5c6fcb35519a6f9ef4918ff866b66508041b7a0b623aa90491dR28-R30)
* Updated condition normalization calls to use the consistent import alias. [[1]](diffhunk://#diff-5d58817874ea81dff0a5f55a23b5117d82bd667dac51d4d7c65e4e0f1b1e6187L257-R260) [[2]](diffhunk://#diff-5d58817874ea81dff0a5f55a23b5117d82bd667dac51d4d7c65e4e0f1b1e6187L303-R310)

These changes collectively improve the robustness and clarity of rule and configuration validation, reducing the risk of misconfiguration due to missing or invalid references.