### PR TITLE
fix: remove checks for nulls and empty values in rule validation

### DIFF
--- a/adminapi/queries/firmware_rule_template_service.go
+++ b/adminapi/queries/firmware_rule_template_service.go
@@ -193,12 +193,6 @@ func validateRule(fr *re.Rule, action *corefw.TemplateApplicableAction) error {
 		if c == nil {
 			return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "Condition is null")
 		}
-		if err := checkConditionNullsOrBlanks(*c); err != nil {
-			return err
-		}
-		if err := checkDuplicateFixedArgListItems(*c); err != nil {
-			return err
-		}
 		if err := checkOperationName(c, GetFirmwareRuleAllowedOperations); err != nil {
 			return err
 		}


### PR DESCRIPTION
This pull request simplifies the validation logic within the `validateRule` function in `firmware_rule_template_service.go` by removing checks for nulls, empty and blanks items in conditions.