### PR TITLE
fix: improve fixed argument validation in rule processing

### DIFF
--- a/adminapi/queries/firmware_rule_template_service.go
+++ b/adminapi/queries/firmware_rule_template_service.go
@@ -198,7 +198,8 @@ func validateRule(fr *re.Rule, action *corefw.TemplateApplicableAction) error {
 		}
 		if (equalOperations(c.GetOperation(), re.StandardOperationIs) && c.GetFreeArg().GetName() == xwcommon.MODEL) ||
 			(equalOperations(c.GetOperation(), re.StandardOperationInList) && c.GetFreeArg().GetName() == xwcommon.IP_ADDRESS) {
-			if _, ok := c.GetFixedArg().GetValue().(string); !ok {
+			fixedArg, ok := c.GetFixedArg().GetValue().(string)
+			if !ok {
 				return xwcommon.NewRemoteErrorAS(
 					http.StatusBadRequest,
 					fmt.Sprintf(
@@ -209,8 +210,10 @@ func validateRule(fr *re.Rule, action *corefw.TemplateApplicableAction) error {
 					),
 				)
 			}
-			if err := checkFixedArgValue(*c, isNotBlank); err != nil {
-				return err
+			if !xutil.IsBlank(fixedArg) {
+				if err := checkFixedArgValue(*c, isNotBlank); err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This pull request makes a minor improvement to the validation logic in the `validateRule` function, ensuring that `checkFixedArgValue` is only called when the `fixedArg` string is not blank. This prevents unnecessary validation checks on empty values.

* Improved validation: In `adminapi/queries/firmware_rule_template_service.go`, the code now checks if `fixedArg` is not blank before calling `checkFixedArgValue`, which helps avoid redundant validation on empty strings. [[1]](diffhunk://#diff-f7377e03624fb8e3e5655856cd59a541e7b57f7c63de4810131f097768753123L201-R202) [[2]](diffhunk://#diff-f7377e03624fb8e3e5655856cd59a541e7b57f7c63de4810131f097768753123R213-R219)