### PR TITLE
Improve rule validation and processing for fixed arguments

### DIFF
--- a/adminapi/queries/firmware_rule_template_service.go
+++ b/adminapi/queries/firmware_rule_template_service.go
@@ -193,12 +193,6 @@ func validateRule(fr *re.Rule, action *corefw.TemplateApplicableAction) error {
 		if c == nil {
 			return xwcommon.NewRemoteErrorAS(http.StatusBadRequest, "Condition is null")
 		}
-		if err := checkConditionNullsOrBlanks(*c); err != nil {
-			return err
-		}
-		if err := checkDuplicateFixedArgListItems(*c); err != nil {
-			return err
-		}
 		if err := checkOperationName(c, GetFirmwareRuleAllowedOperations); err != nil {
 			return err
 		}

--- a/adminapi/queries/firmware_rule_template_service.go
+++ b/adminapi/queries/firmware_rule_template_service.go
@@ -198,7 +198,8 @@ func validateRule(fr *re.Rule, action *corefw.TemplateApplicableAction) error {
 		}
 		if (equalOperations(c.GetOperation(), re.StandardOperationIs) && c.GetFreeArg().GetName() == xwcommon.MODEL) ||
 			(equalOperations(c.GetOperation(), re.StandardOperationInList) && c.GetFreeArg().GetName() == xwcommon.IP_ADDRESS) {
-			if _, ok := c.GetFixedArg().GetValue().(string); !ok {
+			fixedArg, ok := c.GetFixedArg().GetValue().(string)
+			if !ok {
 				return xwcommon.NewRemoteErrorAS(
 					http.StatusBadRequest,
 					fmt.Sprintf(
@@ -209,8 +210,10 @@ func validateRule(fr *re.Rule, action *corefw.TemplateApplicableAction) error {
 					),
 				)
 			}
-			if err := checkFixedArgValue(*c, isNotBlank); err != nil {
-				return err
+			if !xutil.IsBlank(fixedArg) {
+				if err := checkFixedArgValue(*c, isNotBlank); err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This pull request updates the validation logic in the `validateRule` function within `firmware_rule_template_service.go`. The main focus is to simplify condition checks and improve the handling of fixed argument values for certain rule operations.

Validation logic improvements:

* Removed redundant calls to `checkConditionNullsOrBlanks` and `checkDuplicateFixedArgListItems`, streamlining the validation process for rule conditions.
* Refactored the type assertion for `fixedArg` to store the value in a variable, and added a check to only call `checkFixedArgValue` if `fixedArg` is not blank, preventing unnecessary validation errors. [[1]](diffhunk://#diff-f7377e03624fb8e3e5655856cd59a541e7b57f7c63de4810131f097768753123L196-R202) [[2]](diffhunk://#diff-f7377e03624fb8e3e5655856cd59a541e7b57f7c63de4810131f097768753123R213-R219)