### PR TITLE
Add OpenSpec framework for unit test enhancement

### DIFF
--- a/.github/prompts/opsx-apply.prompt.md
+++ b/.github/prompts/opsx-apply.prompt.md
@@ -1,0 +1,149 @@
+---
+description: Implement tasks from an OpenSpec change (Experimental)
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.github/prompts/opsx-archive.prompt.md
+++ b/.github/prompts/opsx-archive.prompt.md
@@ -1,0 +1,154 @@
+---
+description: Archive a completed change in the experimental workflow
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.github/prompts/opsx-explore.prompt.md
+++ b/.github/prompts/opsx-explore.prompt.md
@@ -1,0 +1,170 @@
+---
+description: Enter explore mode - think through ideas, investigate problems, clarify requirements
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.github/prompts/opsx-propose.prompt.md
+++ b/.github/prompts/opsx-propose.prompt.md
@@ -1,0 +1,103 @@
+---
+description: Propose a new change - create it and generate all artifacts in one step
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.github/skills/openspec-apply-change/SKILL.md
+++ b/.github/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.github/skills/openspec-archive-change/SKILL.md
+++ b/.github/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.github/skills/openspec-explore/SKILL.md
+++ b/.github/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.github/skills/openspec-propose/SKILL.md
+++ b/.github/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/openspec/changes/unit-test-enhancement/design.md
+++ b/openspec/changes/unit-test-enhancement/design.md
@@ -1,0 +1,502 @@
+# Unit Test Enhancement - Technical Design
+
+## Overview
+
+This design specifies the technical implementation for dual-mode (mock/real DB) unit testing infrastructure across all xconfadmin modules.
+
+## Architecture
+
+### 1. Test Mode Control Flow
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│                        TEST INITIALIZATION FLOW                          │
+└──────────────────────────────────────────────────────────────────────────┘
+
+     ┌─────────────────┐
+     │   go test       │
+     │   invoked       │
+     └────────┬────────┘
+              │
+              ▼
+     ┌─────────────────┐
+     │   TestMain()    │──────────────────────────────────────────┐
+     │   Entry Point   │                                          │
+     └────────┬────────┘                                          │
+              │                                                   │
+              ▼                                                   │
+     ┌─────────────────────────────┐                              │
+     │ os.Getenv("USE_MOCK_DB")    │                              │
+     └─────────────┬───────────────┘                              │
+                   │                                              │
+     ┌─────────────┴─────────────┐                                │
+     │                           │                                │
+     ▼                           ▼                                │
+┌─────────────┐          ┌─────────────┐                          │
+│ true/1      │          │ false/0     │                          │
+│ Mock Mode   │          │ Real Mode   │                          │
+└──────┬──────┘          └──────┬──────┘                          │
+       │                        │                                 │
+       ▼                        ▼                                 │
+┌──────────────┐         ┌──────────────┐                         │
+│ InitMock     │         │ Connect to   │                         │
+│ Database()   │         │ Cassandra    │                         │
+└──────┬───────┘         └──────┬───────┘                         │
+       │                        │                                 │
+       └───────────┬────────────┘                                 │
+                   │                                              │
+                   ▼                                              │
+          ┌────────────────┐                                      │
+          │ Override       │                                      │
+          │ GetCachedSimple│                                      │
+          │ DaoFunc        │                                      │
+          └────────┬───────┘                                      │
+                   │                                              │
+                   ▼                                              │
+          ┌────────────────┐                                      │
+          │  m.Run()       │◄─────────────────────────────────────┘
+          │  Execute Tests │
+          └────────────────┘
+```
+
+### 2. Mock DAO Interface
+
+The mock DAO must implement the `db.CachedSimpleDao` interface:
+
+```go
+type CachedSimpleDao interface {
+    GetOne(tenantId, tableName, rowKey string) (interface{}, error)
+    GetOneFromCacheOnly(tenantId, tableName, rowKey string) (interface{}, error)
+    SetOne(tenantId, tableName, rowKey string, entity interface{}) error
+    DeleteOne(tenantId, tableName, rowKey string) error
+    GetAllByKeys(tenantId, tableName string, rowKeys []string) ([]interface{}, error)
+    GetAllAsList(tenantId, tableName string, maxResults int) ([]interface{}, error)
+    GetAllAsMap(tenantId, tableName string) (map[interface{}]interface{}, error)
+    GetAllAsShallowMap(tenantId, tableName string) (map[interface{}]interface{}, error)
+    GetKeys(tenantId, tableName string) ([]interface{}, error)
+    RefreshAll(tenantId, tableName string) error
+    RefreshOne(tenantId, tableName, rowKey string) error
+}
+```
+
+### 3. Test Utility Structure per Module
+
+```
+adminapi/
+└── <module>/
+    ├── test_utils.go           ← Mock/Real DB switching logic
+    ├── mocks/                   ← Mock implementations (if needed locally)
+    │   ├── mock_dao.go
+    │   ├── mock_dao_test.go
+    │   ├── mock_database_client.go
+    │   └── test_setup.go
+    └── *_test.go               ← Test files with idempotent tests
+```
+
+### 4. Shared Mock Package Location
+
+```
+adminapi/
+└── dcm/
+    └── mocks/                   ← SHARED mocks used by all modules
+        ├── mock_dao.go          ← MockCachedSimpleDao implementation
+        ├── mock_database_client.go  ← MockDatabaseClient for locks
+        ├── mock_distributed_lock.go ← MockDistributedLock
+        └── test_setup.go        ← Global setup helpers
+```
+
+## Component Designs
+
+### 4.1 test_utils.go Template
+
+Each module requiring DB access needs this pattern:
+
+```go
+package <module>
+
+import (
+    "testing"
+    "github.com/rdkcentral/xconfadmin/adminapi/dcm/mocks"
+    "github.com/rdkcentral/xconfwebconfig/db"
+    xwlogupload "github.com/rdkcentral/xconfwebconfig/shared/logupload"
+)
+
+var mockDaoInstance *mocks.MockCachedSimpleDao
+var useMockDatabase = false
+var originalGetCachedSimpleDaoFunc func() db.CachedSimpleDao
+
+// InitMockDatabase initializes mock mode
+func InitMockDatabase() *mocks.MockCachedSimpleDao {
+    mockDaoInstance = mocks.NewMockCachedSimpleDao()
+    useMockDatabase = true
+    
+    // CRITICAL: Override global DAO function
+    originalGetCachedSimpleDaoFunc = xwlogupload.GetCachedSimpleDaoFunc
+    xwlogupload.GetCachedSimpleDaoFunc = func() db.CachedSimpleDao {
+        return mockDaoInstance
+    }
+    
+    return mockDaoInstance
+}
+
+// DisableMockDatabase restores real mode
+func DisableMockDatabase() {
+    if originalGetCachedSimpleDaoFunc != nil {
+        xwlogupload.GetCachedSimpleDaoFunc = originalGetCachedSimpleDaoFunc
+    }
+    useMockDatabase = false
+    mockDaoInstance = nil
+}
+
+// IsMockDatabaseEnabled returns current mode
+func IsMockDatabaseEnabled() bool {
+    return useMockDatabase
+}
+
+// ClearMockDatabase clears all mock data
+func ClearMockDatabase() {
+    if useMockDatabase && mockDaoInstance != nil {
+        mockDaoInstance.Clear()
+    }
+}
+
+// SkipIfMockDatabase skips integration tests in mock mode
+func SkipIfMockDatabase(t *testing.T) {
+    if useMockDatabase {
+        t.Skip("Skipping integration test in mock mode")
+    }
+}
+
+// GetMockDaoForTesting returns mock for assertions
+func GetMockDaoForTesting() *mocks.MockCachedSimpleDao {
+    return mockDaoInstance
+}
+```
+
+### 4.2 TestMain Template
+
+```go
+func TestMain(m *testing.M) {
+    // Check mode from environment
+    useMock := os.Getenv("USE_MOCK_DB")
+    if useMock == "true" || useMock == "1" || useMock == "" {
+        // Default to mock mode for speed
+        fmt.Println("Using MOCK database")
+        
+        // Initialize mock DB client (prevents distributed lock panics)
+        mockDbClient := mocks.NewMockDatabaseClient()
+        db.SetDatabaseClient(mockDbClient)
+        
+        // Register table configurations
+        registerTableConfigs()
+        
+        // Initialize mock DAO
+        InitMockDatabase()
+        defer DisableMockDatabase()
+    } else {
+        fmt.Println("Using REAL database")
+        // Real DB initialization follows...
+    }
+    
+    // Common setup (config, router, etc.)
+    setupTestEnvironment()
+    
+    // Run tests
+    code := m.Run()
+    
+    // Cleanup
+    teardownTestEnvironment()
+    
+    os.Exit(code)
+}
+```
+
+### 4.3 Idempotent Test Pattern
+
+```go
+// CORRECT: Idempotent test with surgical cleanup
+func TestCreateDeviceSetting(t *testing.T) {
+    // Generate unique ID for this test
+    testID := "test-device-" + uuid.New().String()
+    
+    // Setup: Create test data
+    setting := &logupload.DeviceSettings{
+        ID:              testID,
+        Name:            "Test Device Setting",
+        ApplicationType: "stb",
+    }
+    
+    // Cleanup: Remove only what we created
+    defer func() {
+        if IsMockDatabaseEnabled() {
+            GetMockDaoForTesting().DeleteOne(db.GetDefaultTenantId(), 
+                db.TABLE_DEVICE_SETTINGS, testID)
+        } else {
+            db.GetCachedSimpleDao().DeleteOne(db.GetDefaultTenantId(), 
+                db.TABLE_DEVICE_SETTINGS, testID)
+        }
+    }()
+    
+    // Execute
+    err := CreateDeviceSetting(setting)
+    
+    // Assert
+    assert.NilError(t, err)
+    
+    // Verify by reading back
+    retrieved := GetDeviceSetting(db.GetDefaultTenantId(), testID)
+    assert.Equal(t, setting.Name, retrieved.Name)
+}
+```
+
+### 4.4 Test Helper Functions
+
+```go
+// Helper to create entity with cleanup tracking
+func createTestEntity(t *testing.T, entity interface{}, id string, tableName string) func() {
+    // Insert
+    err := setOneInDao(tableName, id, entity)
+    assert.NilError(t, err)
+    
+    // Return cleanup function
+    return func() {
+        deleteOneFromDao(tableName, id)
+    }
+}
+
+// Usage:
+func TestSomething(t *testing.T) {
+    entity := &MyEntity{ID: "test-123"}
+    cleanup := createTestEntity(t, entity, entity.ID, db.TABLE_MY_ENTITY)
+    defer cleanup()
+    
+    // Test logic...
+}
+```
+
+## Coverage Tracking Design
+
+### Coverage Verification Loop
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                    COVERAGE VERIFICATION WORKFLOW                     │
+└──────────────────────────────────────────────────────────────────────┘
+
+For each test function enhancement:
+
+┌─────────────┐    ┌─────────────┐    ┌─────────────┐    ┌─────────────┐
+│ 1. Modify   │───▶│ 2. Run Mock │───▶│ 3. Run Real │───▶│ 4. Document │
+│    Test     │    │    Tests    │    │    Tests    │    │   Coverage  │
+└─────────────┘    └─────────────┘    └─────────────┘    └─────────────┘
+                         │                  │                   │
+                         ▼                  ▼                   ▼
+                   ┌───────────┐      ┌───────────┐      ┌───────────┐
+                   │ Verify    │      │ Verify    │      │ Record in │
+                   │ Pass + %  │      │ Pass + %  │      │ tasks.md  │
+                   └───────────┘      └───────────┘      └───────────┘
+```
+
+### Coverage Commands
+
+```bash
+# Single function coverage (mock)
+USE_MOCK_DB=true go test -run TestFunctionName \
+    -coverprofile=coverage_mock.out \
+    -coverpkg=./...
+
+# Single function coverage (real)
+USE_MOCK_DB=false go test -run TestFunctionName \
+    -coverprofile=coverage_real.out \
+    -coverpkg=./...
+
+# View coverage
+go tool cover -func=coverage_mock.out | grep FunctionName
+
+# HTML report
+go tool cover -html=coverage_mock.out -o coverage.html
+```
+
+### Coverage Tracking Format
+
+In `tasks.md`, each task records:
+
+```markdown
+### Task X: TestFunctionName enhancement
+
+**Status**: ✅ Completed
+
+**Coverage Results**:
+| Mode | Pass | Coverage | Function Coverage |
+|------|------|----------|-------------------|
+| Mock | ✅   | 85.2%    | 100% (X/X lines)  |
+| Real | ✅   | 85.2%    | 100% (X/X lines)  |
+
+**Changes Made**:
+- Added surgical cleanup
+- Made idempotent
+- Added mock support
+```
+
+## Module-Specific Designs
+
+### DCM Module (Already Has Mocks)
+
+**Current State**: Has mock infrastructure, needs cleanup improvements
+**Changes Required**:
+- Fix double cleanup pattern
+- Make e2e tests idempotent
+- Add coverage tracking
+
+### Queries Module (Partially Has Mocks)
+
+**Current State**: Has test_utils.go, needs standardization
+**Changes Required**:
+- Ensure all tests use mock/real pattern
+- Fix surgical cleanup
+- Remove test dependencies
+
+### Telemetry Module (Has Mocks)
+
+**Current State**: Has mock support
+**Changes Required**:
+- Standardize with other modules
+- Fix cleanup patterns
+- Add coverage tracking
+
+### Setting Module (No Mocks)
+
+**Current State**: No mock infrastructure
+**Changes Required**:
+- Add test_utils.go
+- Add TestMain with mode switching
+- Convert all tests to idempotent pattern
+
+### Canary Module (No Mocks)
+
+**Current State**: No mock infrastructure
+**Changes Required**:
+- Add test_utils.go
+- Add TestMain with mode switching
+- Convert tests to idempotent pattern
+
+### RFC Module (No Mocks)
+
+**Current State**: Has TestMain but no mock switching
+**Changes Required**:
+- Add mock infrastructure to test_utils.go
+- Update TestMain for mode switching
+- Convert tests to idempotent pattern
+
+### Tagging API Module (No Mocks)
+
+**Current State**: No mock infrastructure
+**Changes Required**:
+- Add test_utils.go to taggingapi/tag/
+- Add test_utils.go to taggingapi/config/
+- Add test_utils.go to taggingapi/percentage/
+- Add TestMain with mode switching
+- Convert all tests to idempotent pattern
+
+### Shared Module (No Mocks)
+
+**Current State**: Tests may use real DB directly
+**Changes Required**:
+- Audit each submodule (estbfirmware, firmware, logupload, rfc, change)
+- Add mock support where DB is used
+- Convert tests to idempotent pattern
+
+### Auth Module (No Mocks)
+
+**Current State**: Panics without DB connection
+**Changes Required**:
+- Add test_utils.go
+- Add mock for IDP service
+- Make WebconfigServer initialization conditional
+
+### XCRP Module (No Mocks)
+
+**Current State**: No mock infrastructure
+**Changes Required**:
+- Add test_utils.go
+- Add TestMain with mode switching
+- Convert tests to idempotent pattern
+
+### Configuration IP-MacRule Module (No Mocks)
+
+**Current State**: No mock infrastructure
+**Changes Required**:
+- Add test_utils.go
+- Add TestMain with mode switching
+- Convert tests to idempotent pattern
+
+## File Changes Summary
+
+### New Files to Create
+
+| File | Purpose |
+|------|---------|
+| `adminapi/setting/test_utils.go` | Mock/real switching for setting module |
+| `adminapi/canary/test_utils.go` | Mock/real switching for canary module |
+| `adminapi/auth/test_utils.go` | Mock/real switching for auth module |
+| `adminapi/xcrp/test_utils.go` | Mock/real switching for xcrp module |
+| `adminapi/firmware/test_utils.go` | Mock/real switching for firmware module |
+| `adminapi/configuration/ip-macrule/test_utils.go` | Mock/real switching |
+| `taggingapi/tag/test_utils.go` | Mock/real switching for tag module |
+| `taggingapi/config/test_utils.go` | Mock/real switching for config module |
+| `taggingapi/percentage/test_utils.go` | Mock/real switching for percentage module |
+| `shared/estbfirmware/test_utils.go` | Mock/real switching |
+| `shared/firmware/test_utils.go` | Mock/real switching |
+| `shared/logupload/test_utils.go` | Mock/real switching |
+| `shared/rfc/test_utils.go` | Mock/real switching |
+| `shared/change/test_utils.go` | Mock/real switching |
+
+### Files to Modify
+
+| File | Changes |
+|------|---------|
+| All `*_test.go` files | Idempotent tests, surgical cleanup |
+| Existing `test_utils.go` files | Standardize mock infrastructure |
+| Files with `TestMain` | Add mode switching |
+| Files with `DeleteAllEntities` | Replace with surgical cleanup |
+
+## Testing Strategy
+
+### Unit Test Execution Order
+
+1. **Mock Mode First**: Always run mock mode first (fast feedback)
+2. **Real Mode Second**: Run real mode for integration validation
+3. **Compare Coverage**: Ensure both modes achieve same coverage
+
+### CI/CD Integration
+
+```yaml
+# GitHub Actions example
+jobs:
+  test-mock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Mock Tests
+        run: USE_MOCK_DB=true make cover
+        
+  test-real:
+    runs-on: ubuntu-latest
+    services:
+      cassandra:
+        image: cassandra:4.1
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Real Tests
+        run: USE_MOCK_DB=false make cover
+```
+
+## Acceptance Criteria
+
+1. **Mode Switching**: `USE_MOCK_DB=true|false` controls database mode
+2. **All Tests Pass**: Both modes pass all tests
+3. **Idempotent**: No test depends on another test's execution
+4. **Surgical Cleanup**: Tests only delete data they create
+5. **Coverage Parity**: Mock and real modes achieve same coverage %
+6. **Performance**: Mock mode completes in < 30 seconds
+7. **No Production Changes**: Zero modifications to non-test files

--- a/openspec/changes/unit-test-enhancement/proposal.md
+++ b/openspec/changes/unit-test-enhancement/proposal.md
@@ -1,0 +1,334 @@
+# Unit Test Enhancement Proposal - Mock/Real DB Support
+
+## Summary
+
+Enhance the xconfadmin unit test infrastructure to support **dual-mode testing** with both mock database and real Cassandra database, controlled via environment variable. This enables fast isolated unit tests (mock mode) and integration verification (real DB mode) while ensuring **idempotent** tests with proper cleanup strategies.
+
+## Problem Statement
+
+The current test infrastructure has several issues:
+
+1. **Tests require Cassandra** - Tests fail with connection errors when DB is not available
+2. **Inconsistent mock patterns** - Some modules have mock support, others don't
+3. **Non-idempotent tests** - Some tests call other test functions or have shared state
+4. **Improper cleanup** - Tests perform both `DeleteAllEntities()` and `defer DeleteAllEntities()` (redundant double cleanup)
+5. **Complete table cleanup** - Some tests wipe entire tables instead of just inserted data
+6. **No coverage verification** - No systematic coverage tracking per function
+
+## Goals
+
+1. **Dual-mode support**: Every unit test function supports both mock and real DB
+2. **Command control**: `USE_MOCK_DB=true|false` environment variable controls mode
+3. **Idempotent tests**: No test function calls or depends on other test functions
+4. **Surgical cleanup**: Tests only remove data they inserted
+5. **No production changes**: Only test files modified
+6. **Coverage verification**: Run `make cover` after each test with both modes
+7. **157 test files** across all modules to be enhanced
+
+## Scope
+
+### Modules Using Database (In-Scope)
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    MODULES REQUIRING ENHANCEMENT                        │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐    │
+│  │  adminapi/  │  │  adminapi/  │  │  adminapi/  │  │  adminapi/  │    │
+│  │    dcm/     │  │  telemetry/ │  │  queries/   │  │   change/   │    │
+│  │ (21 tests)  │  │ (15 tests)  │  │ (52 tests)  │  │ (12 tests)  │    │
+│  └─────────────┘  └─────────────┘  └─────────────┘  └─────────────┘    │
+│                                                                         │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐    │
+│  │  adminapi/  │  │  adminapi/  │  │  adminapi/  │  │  adminapi/  │    │
+│  │  setting/   │  │   canary/   │  │   auth/     │  │   xcrp/     │    │
+│  │ (4 tests)   │  │ (2 tests)   │  │ (1 test)    │  │ (2 tests)   │    │
+│  └─────────────┘  └─────────────┘  └─────────────┘  └─────────────┘    │
+│                                                                         │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐    │
+│  │  adminapi/  │  │  adminapi/  │  │ taggingapi/ │  │  shared/    │    │
+│  │  firmware/  │  │    rfc/     │  │   (all)     │  │   (all)     │    │
+│  │ (1 test)    │  │ (5 tests)   │  │ (10 tests)  │  │ (25 tests)  │    │
+│  └─────────────┘  └─────────────┘  └─────────────┘  └─────────────┘    │
+│                                                                         │
+│  ┌─────────────────────────────────────────────────────────────────┐   │
+│  │                    adminapi/configuration/ip-macrule             │   │
+│  │                           (1 test)                                │   │
+│  └─────────────────────────────────────────────────────────────────┘   │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### Non-DB Modules (Out of Scope)
+
+- `util/` - Pure utility functions, no DB access
+- `common/` - Configuration and constants
+- `http/` - HTTP connectors (already has mocks)
+
+## Current Test Count by Module
+
+| Module | Test Files | Tests (Approx) | Has Mock | Has TestMain |
+|--------|-----------|----------------|----------|--------------|
+| adminapi/dcm | 13 | ~80 | ✓ | ✓ |
+| adminapi/queries | 48 | ~200 | ✓ | ✓ |
+| adminapi/telemetry | 10 | ~60 | ✓ | ✓ |
+| adminapi/change | 8 | ~40 | ✗ | ✓ |
+| adminapi/setting | 4 | ~20 | ✗ | ✗ |
+| adminapi/canary | 2 | ~10 | ✗ | ✗ |
+| adminapi/rfc/feature | 3 | ~15 | ✗ | ✓ |
+| adminapi/auth | 1 | ~5 | ✗ | ✗ |
+| adminapi/xcrp | 2 | ~10 | ✗ | ✗ |
+| adminapi/firmware | 1 | ~5 | ✗ | ✗ |
+| adminapi/configuration/ip-macrule | 1 | ~5 | ✗ | ✗ |
+| taggingapi/* | 8 | ~30 | ✗ | ✗ |
+| shared/* | 25 | ~100 | ✗ | ✗ |
+| http/* | 10 | ~20 | ✓ (mocks) | ✓ |
+
+## Non-Goals
+
+- Modifying production code
+- Adding new features to the application
+- Changing database schema
+- Modifying external dependencies
+
+## Technical Approach
+
+### 1. Mock/Real DB Control Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     TEST EXECUTION FLOW                          │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                     Environment Check                            │
+│                  USE_MOCK_DB=true|false                          │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+          ┌───────────────────┴───────────────────┐
+          ▼                                       ▼
+┌─────────────────────┐                 ┌─────────────────────┐
+│   Mock Mode         │                 │   Real DB Mode      │
+│ USE_MOCK_DB=true    │                 │ USE_MOCK_DB=false   │
+├─────────────────────┤                 ├─────────────────────┤
+│ • In-memory DAO     │                 │ • Cassandra DAO     │
+│ • Ultra fast (<1ms) │                 │ • Integration test  │
+│ • No external deps  │                 │ • Full validation   │
+│ • Isolated tests    │                 │ • Real transactions │
+└─────────────────────┘                 └─────────────────────┘
+          │                                       │
+          └───────────────────┬───────────────────┘
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    Same Test Functions                           │
+│              (Both modes use identical test code)                │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 2. Commands to Run Tests
+
+```bash
+# Mock mode (fast, no DB required) - DEFAULT
+USE_MOCK_DB=true go test ./... -cover
+
+# Real DB mode (integration, requires Cassandra)
+USE_MOCK_DB=false go test ./... -cover
+
+# Coverage for specific function (mock)
+USE_MOCK_DB=true go test -run TestFunctionName -cover -coverprofile=func_mock.out
+
+# Coverage for specific function (real)
+USE_MOCK_DB=false go test -run TestFunctionName -cover -coverprofile=func_real.out
+```
+
+### 3. Cleanup Strategy Changes
+
+**CURRENT (Problematic)**:
+```go
+func TestSomething(t *testing.T) {
+    DeleteAllEntities()        // ← Problem: Wipes ALL data
+    defer DeleteAllEntities()  // ← Problem: Double cleanup, wipes ALL data
+    
+    // Create test data
+    entity := createTestEntity()
+    
+    // Test logic...
+}
+```
+
+**PROPOSED (Surgical)**:
+```go
+func TestSomething(t *testing.T) {
+    // Track what we insert
+    var insertedIDs []string
+    
+    // Create test data
+    entity := createTestEntity("test-id-123")
+    insertedIDs = append(insertedIDs, entity.ID)
+    
+    // Cleanup ONLY what we inserted
+    defer func() {
+        for _, id := range insertedIDs {
+            deleteEntity(id)
+        }
+    }()
+    
+    // Test logic...
+}
+```
+
+### 4. Test Independence Pattern
+
+**CURRENT (Non-idempotent)**:
+```go
+func TestCreate(t *testing.T) {
+    entity := createEntity()
+    // leaves entity in DB
+}
+
+func TestRead(t *testing.T) {
+    // Depends on TestCreate having run first!
+    entity := getEntity(id)  // ← FAILS if TestCreate didn't run
+}
+```
+
+**PROPOSED (Idempotent)**:
+```go
+func TestCreate(t *testing.T) {
+    entity := createEntity()
+    defer deleteEntity(entity.ID)
+    
+    // Verify creation
+    assert.NotNil(t, entity)
+}
+
+func TestRead(t *testing.T) {
+    // Setup its own data
+    entity := createEntity()
+    defer deleteEntity(entity.ID)
+    
+    // Test read logic
+    retrieved := getEntity(entity.ID)
+    assert.Equal(t, entity.ID, retrieved.ID)
+}
+```
+
+## Database Tables Accessed by Module
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                      TABLE ACCESS BY MODULE                              │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  DCM Module:                                                             │
+│  ├── TABLE_DCM_RULE              ├── TABLE_LOG_FILE                     │
+│  ├── TABLE_LOG_FILE_LIST         ├── TABLE_LOG_UPLOAD_SETTINGS          │
+│  ├── TABLE_DEVICE_SETTINGS       ├── TABLE_VOD_SETTINGS                 │
+│  └── TABLE_UPLOAD_REPOSITORY     └── TABLE_XCONF_CHANGE                 │
+│                                                                          │
+│  Queries Module:                                                         │
+│  ├── TABLE_FIRMWARE_CONFIG       ├── TABLE_FIRMWARE_RULE                │
+│  ├── TABLE_FIRMWARE_RULE_TEMPLATE├── TABLE_IP_ADDRESS_GROUP             │
+│  ├── TABLE_MAC_LIST              ├── TABLE_MODELS                       │
+│  ├── TABLE_ENVIRONMENTS          ├── TABLE_NAMESPACED_LISTS             │
+│  └── TABLE_PERCENT_FILTER_VALUE  └── TABLE_FEATURE                      │
+│                                                                          │
+│  Telemetry Module:                                                       │
+│  ├── TABLE_TELEMETRY_RULES       ├── TABLE_TELEMETRY_TWO_RULES          │
+│  ├── TABLE_TELEMETRY_TWO_PROFILES├── TABLE_PERMANENT_TELEMETRY_PROFILE  │
+│  └── TABLE_TARGETING_RULE                                                │
+│                                                                          │
+│  RFC Module:                                                             │
+│  ├── TABLE_FEATURE               ├── TABLE_FEATURE_RULE                 │
+│  └── TABLE_FEATURE_CONTROL_SETTING                                       │
+│                                                                          │
+│  Change Module:                                                          │
+│  ├── TABLE_XCONF_CHANGE          ├── TABLE_TELEMETRY_TWO_CHANGE         │
+│  └── TABLE_APPROVED_CHANGES                                              │
+│                                                                          │
+│  Tagging API:                                                            │
+│  ├── TABLE_FIRMWARE_RULE         ├── TABLE_TAGS                         │
+│  └── TABLE_TAG_MEMBERS                                                   │
+│                                                                          │
+│  Setting Module:                                                         │
+│  ├── TABLE_SETTING_PROFILE       ├── TABLE_SETTING_RULE                 │
+│  └── TABLE_SETTING_TYPE                                                  │
+│                                                                          │
+│  Canary Module:                                                          │
+│  └── TABLE_CANARY_SETTINGS                                               │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## Issues Identified for Resolution
+
+### Issue 1: Double Cleanup Pattern
+**Files affected**: 15+ test files
+**Pattern**:
+```go
+DeleteAllEntities()
+defer DeleteAllEntities()  // Redundant
+```
+**Fix**: Remove initial `DeleteAllEntities()`, only use targeted cleanup
+
+### Issue 2: Complete Table Wipe
+**Files affected**: All modules with `DeleteAllEntities()`
+**Pattern**:
+```go
+func DeleteAllEntities() {
+    for _, table := range db.GetAllTableInfo() {
+        cassandraClient.DeleteAllXconfData(table)  // Wipes EVERYTHING
+    }
+}
+```
+**Fix**: Replace with surgical delete of only inserted data
+
+### Issue 3: Test Function Dependencies
+**Files affected**: e2e test files
+**Pattern**: `TestAllDeviceSettingsApis` - One giant function testing multiple operations
+**Fix**: Split into independent test functions, each with own setup/teardown
+
+### Issue 4: Missing Mock Support
+**Modules needing mocks**:
+- adminapi/setting
+- adminapi/canary
+- adminapi/auth
+- adminapi/xcrp
+- adminapi/firmware
+- adminapi/configuration/ip-macrule
+- taggingapi/*
+- shared/*
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Mock DAO doesn't match real DAO behavior | Tests pass with mock but fail with real | Run both modes in CI; periodic real DB validation |
+| Surgical cleanup misses data | Data pollution between tests | Generate unique IDs per test; run with `-race` flag |
+| Test isolation breaks shared setup | Tests fail intermittently | Audit all test functions for shared state |
+| Coverage differs between modes | False confidence | Track and compare coverage metrics |
+
+## Success Criteria
+
+1. **All tests pass** with `USE_MOCK_DB=true`
+2. **All tests pass** with `USE_MOCK_DB=false` (when DB available)
+3. **No test function calls another test function**
+4. **Each test cleans up only its own data**
+5. **Coverage documented** after each test function enhancement
+6. **Mock mode completes in < 30 seconds** for full suite
+
+## Open Questions
+
+1. Should we add `SkipIfRealDatabase(t)` for tests that only make sense with mocks?
+2. How to handle TestMain collision when multiple test files in same package?
+3. Should we create a shared test infrastructure package?
+4. How to verify surgical cleanup is complete without full table scan?
+
+## Related Files
+
+- Sample implementation: `sample/xconfadmin/adminapi/dcm/` (reference only, will be removed)
+- Mock DAO: `adminapi/dcm/mocks/mock_dao.go`
+- Mock DB Client: `adminapi/dcm/mocks/mock_database_client.go`
+- Test utils pattern: `adminapi/dcm/test_utils.go`

--- a/openspec/changes/unit-test-enhancement/specs/change-module-spec.md
+++ b/openspec/changes/unit-test-enhancement/specs/change-module-spec.md
@@ -1,0 +1,246 @@
+# Change Module Specification
+
+## Module Overview
+
+**Package**: `adminapi/change/`  
+**Priority**: P1 - High  
+**Status**: No mocks, needs test_utils.go
+
+The Change module handles change management workflow - creating, approving, and rejecting configuration changes that require review.
+
+---
+
+## Architecture
+
+```
+adminapi/change/
+├── Core Change Management
+│   ├── change_handler.go               # Change CRUD handlers
+│   ├── change_handler_test.go          # TestMain, handler tests
+│   ├── change_service.go               # Business logic
+│   └── change_service_test.go          # Service tests
+│
+└── Telemetry Changes
+    ├── telemetry_profile_handler.go
+    ├── telemetry_profile_handler_test.go
+    ├── telemetry_two_change_handler.go
+    ├── telemetry_two_change_handler_test.go
+    ├── telemetry_two_change_service.go
+    └── telemetry_two_change_service_test.go
+```
+
+---
+
+## Database Tables Used
+
+| Table Name | Operations | Entity Type | DAO Type |
+|------------|------------|-------------|----------|
+| `TABLE_XCONF_CHANGE` | CRUD | `change.Change` | **SimpleDao** |
+| `TABLE_XCONF_APPROVED_CHANGE` | CRUD | `change.Change` | **SimpleDao** |
+| `TABLE_TELEMETRY_CHANGES` | CRUD | `change.Change` | **SimpleDao** |
+| `TABLE_TELEMETRY_APPROVED_CHANGES` | CRUD | `change.Change` | **SimpleDao** |
+| `TABLE_TELEMETRY_TWO_CHANGES` | CRUD | `change.Change` | **SimpleDao** |
+| `TABLE_TELEMETRY_APPROVED_TWO_CHANGES` | CRUD | `change.Change` | **SimpleDao** |
+
+**CRITICAL**: This module uses `db.GetSimpleDao()` NOT `db.GetCachedSimpleDao()`!
+
+---
+
+## Use Cases
+
+### UC-CHG-001: Change Request Creation
+
+**Description**: Create change requests for configuration modifications.
+
+**API Endpoints**:
+- POST `/change/create` - Create change request
+- GET `/change/pending` - List pending changes
+- GET `/change/{id}` - Get change by ID
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-CHG-001-01 | Create valid change | 201 Created | ⚠️ Needs mock |
+| TC-CHG-001-02 | Get all pending | 200 OK + list | ⚠️ Needs mock |
+| TC-CHG-001-03 | Get change by ID | 200 OK + entity | ⚠️ Needs mock |
+| TC-CHG-001-04 | Get non-existent | 404 Not Found | 🔲 Not tested |
+
+---
+
+### UC-CHG-002: Change Approval Workflow
+
+**Description**: Approve or reject pending changes.
+
+**API Endpoints**:
+- POST `/change/approve/{id}` - Approve change
+- POST `/change/reject/{id}` - Reject change
+- GET `/change/approved` - List approved changes
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-CHG-002-01 | Approve valid change | 200 OK | ⚠️ Needs mock |
+| TC-CHG-002-02 | Approve non-existent | 404 Not Found | 🔲 Not tested |
+| TC-CHG-002-03 | Reject valid change | 200 OK | ⚠️ Needs mock |
+| TC-CHG-002-04 | Get approved changes | 200 OK + list | ⚠️ Needs mock |
+
+---
+
+### UC-CHG-003: Telemetry Two Changes
+
+**Description**: Change management for Telemetry 2.0 profiles.
+
+**API Endpoints**:
+- POST `/change/telemetry/v2/pending` - List pending
+- POST `/change/telemetry/v2/approve/{id}` - Approve
+- POST `/change/telemetry/v2/reject/{id}` - Reject
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-CHG-003-01 | Get telemetry v2 pending | 200 OK + list | ⚠️ Needs mock |
+| TC-CHG-003-02 | Approve telemetry v2 | 200 OK | ⚠️ Needs mock |
+| TC-CHG-003-03 | Reject telemetry v2 | 200 OK | ⚠️ Needs mock |
+
+---
+
+## Current Issues
+
+### Issue CHG-001: Uses SimpleDao Instead of CachedSimpleDao
+
+**File**: `shared/change/change.go`
+
+**Current Code**:
+```go
+// Uses GetSimpleDao() - different DAO type!
+db.GetSimpleDao().GetOne(db.TABLE_XCONF_CHANGE, id)
+db.GetSimpleDao().SetOne(db.TABLE_XCONF_CHANGE, id, entity)
+```
+
+**Impact**: Need separate MockSimpleDao implementation.
+
+**Solution**:
+1. Create `mock_simple_dao.go`
+2. Implement SimpleDao interface
+3. Register mock in test setup
+
+---
+
+### Issue CHG-002: No test_utils.go
+
+**Solution**: Create test_utils.go with mock support.
+
+```go
+// adminapi/change/test_utils.go
+package change
+
+import (
+    "os"
+    "testing"
+    "github.com/rdkcentral/xconfadmin/adminapi/dcm/mocks"
+)
+
+var mockSimpleDao *mocks.MockSimpleDao
+
+func IsMockDatabaseEnabled() bool {
+    return os.Getenv("USE_MOCK_DB") == "true"
+}
+
+func InitMockDatabase() {
+    mockSimpleDao = mocks.NewMockSimpleDao()
+    db.SetMockSimpleDao(mockSimpleDao)
+}
+
+func ClearMockDatabase() {
+    if mockSimpleDao != nil {
+        mockSimpleDao.Clear()
+    }
+}
+```
+
+---
+
+## Test Data Fixtures
+
+```go
+// Change fixture
+func NewTestChange(id, entityId, entityType, operation string) *change.Change {
+    return &change.Change{
+        ID:         id,
+        EntityId:   entityId,
+        EntityType: entityType,
+        Operation:  operation,
+        Author:     "test-user",
+        Updated:    time.Now().UnixMilli(),
+    }
+}
+
+// Create change fixture
+func NewTestCreateChange(id string, entity interface{}) *change.Change {
+    return &change.Change{
+        ID:         id,
+        EntityId:   uuid.New().String(),
+        EntityType: "FirmwareRule",
+        Operation:  "CREATE",
+        OldEntity:  nil,
+        NewEntity:  entity,
+        Author:     "test-user",
+        Updated:    time.Now().UnixMilli(),
+    }
+}
+
+// Update change fixture
+func NewTestUpdateChange(id string, oldEntity, newEntity interface{}) *change.Change {
+    return &change.Change{
+        ID:         id,
+        EntityId:   uuid.New().String(),
+        EntityType: "FirmwareRule",
+        Operation:  "UPDATE",
+        OldEntity:  oldEntity,
+        NewEntity:  newEntity,
+        Author:     "test-user",
+        Updated:    time.Now().UnixMilli(),
+    }
+}
+
+// Delete change fixture
+func NewTestDeleteChange(id string, entity interface{}) *change.Change {
+    return &change.Change{
+        ID:         id,
+        EntityId:   uuid.New().String(),
+        EntityType: "FirmwareRule",
+        Operation:  "DELETE",
+        OldEntity:  entity,
+        NewEntity:  nil,
+        Author:     "test-user",
+        Updated:    time.Now().UnixMilli(),
+    }
+}
+```
+
+---
+
+## Coverage Goals
+
+| File | Current | Target | Focus Areas |
+|------|---------|--------|-------------|
+| change_handler.go | ~50% | 85% | All endpoints |
+| change_service.go | ~55% | 85% | Approval flow |
+| telemetry_two_change_handler.go | ~45% | 85% | v2 changes |
+| telemetry_two_change_service.go | ~50% | 85% | v2 service |
+
+---
+
+## Test Execution Commands
+
+```bash
+# Run change module tests with mock
+USE_MOCK_DB=true go test -v ./adminapi/change/... -count=1
+
+# Run with coverage
+USE_MOCK_DB=true go test ./adminapi/change/... -coverprofile=change.out
+go tool cover -func=change.out
+```

--- a/openspec/changes/unit-test-enhancement/specs/database-tables-spec.md
+++ b/openspec/changes/unit-test-enhancement/specs/database-tables-spec.md
@@ -1,0 +1,346 @@
+# Database Tables Specification
+
+## Overview
+
+Complete mapping of all Cassandra tables used by xconfadmin, their entity types, and which modules access them.
+
+---
+
+## Tables by Category
+
+### DCM (Device Configuration Management)
+
+| Table Constant | Cassandra Table | Entity Type | DAO Type |
+|----------------|-----------------|-------------|----------|
+| `TABLE_DEVICE_SETTINGS` | device_settings | `logupload.DeviceSettings` | CachedSimpleDao |
+| `TABLE_VOD_SETTINGS` | vod_settings | `logupload.VodSettings` | CachedSimpleDao |
+| `TABLE_LOG_UPLOAD_SETTINGS` | log_upload_settings | `logupload.LogUploadSettings` | CachedSimpleDao |
+| `TABLE_UPLOAD_REPOSITORY` | upload_repository | `logupload.UploadRepository` | CachedSimpleDao |
+| `TABLE_DCM_RULES` | dcm_rules | `logupload.DCMGenericRule` | CachedSimpleDao |
+| `TABLE_LOG_FILES` | log_files | `logupload.LogFile` | CachedSimpleDao |
+| `TABLE_LOG_FILE_GROUPS` | log_file_groups | `logupload.LogFileGroup` | CachedSimpleDao |
+| `TABLE_LOG_FILE_LISTS` | log_file_lists | `logupload.LogFileList` | CachedSimpleDao |
+
+### Core Configuration
+
+| Table Constant | Cassandra Table | Entity Type | DAO Type |
+|----------------|-----------------|-------------|----------|
+| `TABLE_MODELS` | models | `shared.Model` | CachedSimpleDao |
+| `TABLE_ENVIRONMENTS` | environments | `shared.Environment` | CachedSimpleDao |
+| `TABLE_APP_SETTINGS` | app_settings | `common.ApplicationSetting` | CachedSimpleDao |
+
+### Firmware
+
+| Table Constant | Cassandra Table | Entity Type | DAO Type |
+|----------------|-----------------|-------------|----------|
+| `TABLE_FIRMWARE_CONFIGS` | firmware_configs | `firmware.FirmwareConfig` | CachedSimpleDao |
+| `TABLE_FIRMWARE_RULES` | firmware_rules | `firmware.FirmwareRule` | CachedSimpleDao |
+| `TABLE_FIRMWARE_RULE_TEMPLATES` | firmware_rule_templates | `firmware.FirmwareRuleTemplate` | CachedSimpleDao |
+
+### Telemetry
+
+| Table Constant | Cassandra Table | Entity Type | DAO Type |
+|----------------|-----------------|-------------|----------|
+| `TABLE_TELEMETRY_PROFILES` | telemetry_profiles | `logupload.TelemetryProfile` | CachedSimpleDao |
+| `TABLE_TELEMETRY_RULES` | telemetry_rules | `logupload.TelemetryRule` | CachedSimpleDao |
+| `TABLE_PERMANENT_TELEMETRY_PROFILES` | permanent_telemetry_profiles | `logupload.PermanentTelemetryProfile` | CachedSimpleDao |
+| `TABLE_TELEMETRY_TWO_PROFILES` | telemetry_two_profiles | `logupload.TelemetryTwoProfile` | CachedSimpleDao |
+| `TABLE_TELEMETRY_TWO_RULES` | telemetry_two_rules | `logupload.TelemetryTwoRule` | CachedSimpleDao |
+
+### Change Management
+
+| Table Constant | Cassandra Table | Entity Type | DAO Type |
+|----------------|-----------------|-------------|----------|
+| `TABLE_XCONF_CHANGE` | xconf_change | `change.Change` | **SimpleDao** |
+| `TABLE_XCONF_APPROVED_CHANGE` | xconf_approved_change | `change.Change` | **SimpleDao** |
+| `TABLE_TELEMETRY_CHANGES` | telemetry_changes | `change.Change` | **SimpleDao** |
+| `TABLE_TELEMETRY_APPROVED_CHANGES` | telemetry_approved_changes | `change.Change` | **SimpleDao** |
+| `TABLE_TELEMETRY_TWO_CHANGES` | telemetry_two_changes | `change.Change` | **SimpleDao** |
+| `TABLE_TELEMETRY_APPROVED_TWO_CHANGES` | telemetry_approved_two_changes | `change.Change` | **SimpleDao** |
+
+### Features/RFC
+
+| Table Constant | Cassandra Table | Entity Type | DAO Type |
+|----------------|-----------------|-------------|----------|
+| `TABLE_FEATURES` | features | `rfc.Feature` | CachedSimpleDao |
+| `TABLE_FEATURE_CONTROL_RULES` | feature_control_rules | `rfc.FeatureRule` | CachedSimpleDao |
+
+### Settings
+
+| Table Constant | Cassandra Table | Entity Type | DAO Type |
+|----------------|-----------------|-------------|----------|
+| `TABLE_SETTING_PROFILES` | setting_profiles | `logupload.SettingProfile` | CachedSimpleDao |
+| `TABLE_SETTING_RULES` | setting_rules | `logupload.SettingRule` | CachedSimpleDao |
+
+### Lists
+
+| Table Constant | Cassandra Table | Entity Type | DAO Type |
+|----------------|-----------------|-------------|----------|
+| `TABLE_NS_LISTS` | namespaced_lists | `shared.NamespacedList` | CachedSimpleDao |
+| `TABLE_IP_ADDRESS_GROUPS` | ip_address_groups | `shared.IpAddressGroup` | CachedSimpleDao |
+| `TABLE_MAC_LISTS` | mac_lists | `shared.MacList` | CachedSimpleDao |
+
+### Filters
+
+| Table Constant | Cassandra Table | Entity Type | DAO Type |
+|----------------|-----------------|-------------|----------|
+| `TABLE_SINGLETON_FILTER_VALUE` | singleton_filter_value | `estbfirmware.SingletonFilterValue` | CachedSimpleDao |
+| `TABLE_PERCENT_FILTER` | percent_filter | `estbfirmware.PercentFilter` | CachedSimpleDao |
+| `TABLE_IP_FILTER` | ip_filter | `estbfirmware.IpFilter` | CachedSimpleDao |
+
+### Logs
+
+| Table Constant | Cassandra Table | Entity Type | DAO Type |
+|----------------|-----------------|-------------|----------|
+| `TABLE_LOGS` | logs | Log entries | **ListingDao** |
+
+### Tags
+
+| Table Constant | Cassandra Table | Entity Type | DAO Type |
+|----------------|-----------------|-------------|----------|
+| `TABLE_TAGS` | tags | `tag.Tag` | CachedSimpleDao |
+| `TABLE_TAG_MEMBERS` | tag_members | `tag.TagMember` | CachedSimpleDao |
+
+---
+
+## DAO Type Distribution
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      DAO TYPE USAGE                          │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│  CachedSimpleDao                                            │
+│  ════════════════════════════════════════════════════════   │
+│  39 files use GetCachedSimpleDao()                          │
+│  Tables: ALL except change tables and logs                   │
+│  Features: Caching, fast reads                               │
+│                                                              │
+│  SimpleDao                                                   │
+│  ════════════════════════════════════════════════════════   │
+│  1 file uses GetSimpleDao(): shared/change/change.go        │
+│  Tables: All *_CHANGE and *_APPROVED_CHANGE tables          │
+│  Features: No caching, direct DB access                      │
+│                                                              │
+│  ListingDao                                                  │
+│  ════════════════════════════════════════════════════════   │
+│  1 file uses GetListingDao(): shared/estbfirmware/          │
+│  Tables: TABLE_LOGS                                          │
+│  Features: Range queries, time-series data                   │
+│                                                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Table Usage by Module
+
+### adminapi/dcm/
+
+```go
+// Production files
+logrepo_settings_service.go:
+  db.GetCachedSimpleDao().GetAllAsList(db.TABLE_UPLOAD_REPOSITORY, 0)
+  db.GetCachedSimpleDao().GetOne(db.TABLE_UPLOAD_REPOSITORY, id)
+  db.GetCachedSimpleDao().SetOne(db.TABLE_UPLOAD_REPOSITORY, id, entity)
+  db.GetCachedSimpleDao().DeleteOne(db.TABLE_UPLOAD_REPOSITORY, id)
+
+device_settings_service.go:
+  db.GetCachedSimpleDao().GetAllAsList(db.TABLE_DEVICE_SETTINGS, 0)
+  db.GetCachedSimpleDao().GetOne(db.TABLE_DEVICE_SETTINGS, id)
+  db.GetCachedSimpleDao().SetOne(db.TABLE_DEVICE_SETTINGS, id, entity)
+  db.GetCachedSimpleDao().DeleteOne(db.TABLE_DEVICE_SETTINGS, id)
+
+vod_settings_service.go:
+  db.GetCachedSimpleDao().GetAllAsList(db.TABLE_VOD_SETTINGS, 0)
+  db.GetCachedSimpleDao().GetOne(db.TABLE_VOD_SETTINGS, id)
+  db.GetCachedSimpleDao().SetOne(db.TABLE_VOD_SETTINGS, id, entity)
+  db.GetCachedSimpleDao().DeleteOne(db.TABLE_VOD_SETTINGS, id)
+```
+
+### adminapi/queries/
+
+```go
+// Model operations
+model_service.go:
+  db.GetCachedSimpleDao().GetAllAsList(db.TABLE_MODELS, 0)
+  db.GetCachedSimpleDao().GetOne(db.TABLE_MODELS, id)
+  db.GetCachedSimpleDao().SetOne(db.TABLE_MODELS, id, entity)
+  db.GetCachedSimpleDao().DeleteOne(db.TABLE_MODELS, id)
+
+// Environment operations
+environment_service.go:
+  db.GetCachedSimpleDao().GetAllAsList(db.TABLE_ENVIRONMENTS, 0)
+  db.GetCachedSimpleDao().GetOne(db.TABLE_ENVIRONMENTS, id)
+  db.GetCachedSimpleDao().SetOne(db.TABLE_ENVIRONMENTS, id, entity)
+  db.GetCachedSimpleDao().DeleteOne(db.TABLE_ENVIRONMENTS, id)
+
+// Firmware config operations
+firmware_config_service.go:
+  db.GetCachedSimpleDao().GetAllAsList(db.TABLE_FIRMWARE_CONFIGS, 0)
+  db.GetCachedSimpleDao().GetOne(db.TABLE_FIRMWARE_CONFIGS, id)
+  db.GetCachedSimpleDao().SetOne(db.TABLE_FIRMWARE_CONFIGS, id, entity)
+  db.GetCachedSimpleDao().DeleteOne(db.TABLE_FIRMWARE_CONFIGS, id)
+
+// Firmware rule operations
+firmware_rule_service.go:
+  db.GetCachedSimpleDao().GetAllAsList(db.TABLE_FIRMWARE_RULES, 0)
+  db.GetCachedSimpleDao().GetOne(db.TABLE_FIRMWARE_RULES, id)
+  db.GetCachedSimpleDao().SetOne(db.TABLE_FIRMWARE_RULES, id, entity)
+  db.GetCachedSimpleDao().DeleteOne(db.TABLE_FIRMWARE_RULES, id)
+```
+
+### shared/change/
+
+```go
+// Uses GetSimpleDao (NOT GetCachedSimpleDao)
+change.go:
+  db.GetSimpleDao().GetOne(db.TABLE_XCONF_CHANGE, id)
+  db.GetSimpleDao().SetOne(db.TABLE_XCONF_CHANGE, id, entity)
+  db.GetSimpleDao().DeleteOne(db.TABLE_XCONF_CHANGE, id)
+  db.GetSimpleDao().GetAllAsList(db.TABLE_XCONF_CHANGE, 0)
+  
+  db.GetSimpleDao().GetOne(db.TABLE_XCONF_APPROVED_CHANGE, id)
+  db.GetSimpleDao().SetOne(db.TABLE_XCONF_APPROVED_CHANGE, id, entity)
+  
+  // Telemetry change tables
+  db.GetSimpleDao().GetOne(db.TABLE_TELEMETRY_CHANGES, id)
+  db.GetSimpleDao().GetOne(db.TABLE_TELEMETRY_APPROVED_CHANGES, id)
+  db.GetSimpleDao().GetOne(db.TABLE_TELEMETRY_TWO_CHANGES, id)
+  db.GetSimpleDao().GetOne(db.TABLE_TELEMETRY_APPROVED_TWO_CHANGES, id)
+```
+
+### shared/estbfirmware/
+
+```go
+// Uses GetListingDao for logs
+config_change_logs.go:
+  db.GetListingDao().SetOne(db.TABLE_LOGS, key, logEntry)
+  db.GetListingDao().GetRange(db.TABLE_LOGS, startKey, endKey, maxResults)
+```
+
+### common/
+
+```go
+struct.go:
+  db.GetCachedSimpleDao().GetAllAsList(db.TABLE_DCM_RULES, 0)
+  db.GetCachedSimpleDao().GetOne(db.TABLE_DCM_RULES, id)
+  db.GetCachedSimpleDao().GetAllAsList(db.TABLE_ENVIRONMENTS, 0)
+  db.GetCachedSimpleDao().GetOne(db.TABLE_ENVIRONMENTS, id)
+  db.GetCachedSimpleDao().GetAllAsList(db.TABLE_MODELS, 0)
+  db.GetCachedSimpleDao().GetOne(db.TABLE_MODELS, id)
+  db.GetCachedSimpleDao().SetOne(db.TABLE_APP_SETTINGS, id, entity)
+  db.GetCachedSimpleDao().GetOne(db.TABLE_APP_SETTINGS, id)
+```
+
+---
+
+## Entity Type Definitions
+
+### Key Entities
+
+```go
+// logupload.DeviceSettings
+type DeviceSettings struct {
+    ID                    string   `json:"id"`
+    Name                  string   `json:"name"`
+    CheckOnReboot         bool     `json:"checkOnReboot"`
+    SettingsAreActive     bool     `json:"settingsAreActive"`
+    Schedule              Schedule `json:"schedule"`
+    ApplicationType       string   `json:"applicationType"`
+}
+
+// shared.Model
+type Model struct {
+    ID          string `json:"id"`
+    Description string `json:"description"`
+}
+
+// shared.Environment
+type Environment struct {
+    ID          string `json:"id"`
+    Description string `json:"description"`
+}
+
+// firmware.FirmwareConfig
+type FirmwareConfig struct {
+    ID               string `json:"id"`
+    Description      string `json:"description"`
+    FirmwareFilename string `json:"firmwareFilename"`
+    FirmwareVersion  string `json:"firmwareVersion"`
+    ApplicationType  string `json:"applicationType"`
+}
+
+// firmware.FirmwareRule
+type FirmwareRule struct {
+    ID              string `json:"id"`
+    Name            string `json:"name"`
+    Type            string `json:"type"`
+    Rule            Rule   `json:"rule"`
+    ApplicationType string `json:"applicationType"`
+}
+
+// change.Change
+type Change struct {
+    ID             string      `json:"id"`
+    EntityId       string      `json:"entityId"`
+    EntityType     string      `json:"entityType"`
+    Operation      string      `json:"operation"`
+    OldEntity      interface{} `json:"oldEntity"`
+    NewEntity      interface{} `json:"newEntity"`
+    Author         string      `json:"author"`
+    ApprovedUser   string      `json:"approvedUser"`
+    Updated        int64       `json:"updated"`
+}
+```
+
+---
+
+## Mock Data Requirements
+
+### Per-Table Test Data
+
+| Table | Min Test Records | Fixture Function |
+|-------|-----------------|------------------|
+| DEVICE_SETTINGS | 5 | `NewTestDeviceSetting(id)` |
+| VOD_SETTINGS | 3 | `NewTestVodSettings(id)` |
+| LOG_UPLOAD_SETTINGS | 3 | `NewTestLogUploadSettings(id)` |
+| UPLOAD_REPOSITORY | 2 | `NewTestUploadRepository(id)` |
+| MODELS | 5 | `NewTestModel(id)` |
+| ENVIRONMENTS | 3 | `NewTestEnvironment(id)` |
+| FIRMWARE_CONFIGS | 5 | `NewTestFirmwareConfig(id)` |
+| FIRMWARE_RULES | 10 | `NewTestFirmwareRule(id)` |
+| TELEMETRY_PROFILES | 3 | `NewTestTelemetryProfile(id)` |
+| TELEMETRY_RULES | 5 | `NewTestTelemetryRule(id)` |
+| FEATURES | 5 | `NewTestFeature(id)` |
+| FEATURE_CONTROL_RULES | 5 | `NewTestFeatureRule(id)` |
+| XCONF_CHANGE | 10 | `NewTestChange(id)` |
+| NS_LISTS | 5 | `NewTestNamespacedList(id)` |
+
+---
+
+## Cache Refresh Requirements
+
+Tables that require cache refresh after modifications:
+
+```go
+// After SetOne or DeleteOne, refresh cache
+func refreshTableCache(tableName string) error {
+    return db.GetCachedSimpleDao().RefreshAll(tableName)
+}
+
+// Tables requiring refresh
+var cachedTables = []string{
+    db.TABLE_DEVICE_SETTINGS,
+    db.TABLE_VOD_SETTINGS,
+    db.TABLE_LOG_UPLOAD_SETTINGS,
+    db.TABLE_UPLOAD_REPOSITORY,
+    db.TABLE_MODELS,
+    db.TABLE_ENVIRONMENTS,
+    db.TABLE_FIRMWARE_CONFIGS,
+    db.TABLE_FIRMWARE_RULES,
+    db.TABLE_FEATURES,
+    db.TABLE_FEATURE_CONTROL_RULES,
+    // ... etc
+}
+```

--- a/openspec/changes/unit-test-enhancement/specs/dcm-module-spec.md
+++ b/openspec/changes/unit-test-enhancement/specs/dcm-module-spec.md
@@ -1,0 +1,459 @@
+# DCM Module Specification
+
+## Module Overview
+
+**Package**: `adminapi/dcm/`  
+**Priority**: P0 - Critical  
+**Status**: Has mocks, needs idempotent refactoring
+
+The DCM (Device Configuration Management) module handles device settings, log upload configurations, VOD settings, and upload repository management.
+
+---
+
+## Architecture
+
+```
+adminapi/dcm/
+├── Production Code
+│   ├── device_settings_handler.go      # HTTP handlers for device settings
+│   ├── device_settings_service.go      # Business logic for device settings
+│   ├── vod_settings_handler.go         # HTTP handlers for VOD settings
+│   ├── vod_settings_service.go         # Business logic for VOD settings
+│   ├── logupload_settings_handler.go   # HTTP handlers for log upload
+│   ├── logupload_settings_service.go   # Business logic for log upload
+│   ├── logrepo_settings_handler.go     # HTTP handlers for log repositories
+│   ├── logrepo_settings_service.go     # Business logic for log repositories
+│   ├── dcmformula_handler.go           # DCM formula management
+│   ├── dcmformula_service.go           # DCM formula business logic
+│   └── test_page_controller.go         # Test page controller
+│
+├── Test Code
+│   ├── dcmformula_test.go              # TestMain, integration tests
+│   ├── device_settings_e2e_test.go     # E2E device settings tests
+│   ├── device_settings_handler_test.go # Handler unit tests
+│   ├── vod_settings_e2e_test.go        # E2E VOD settings tests
+│   ├── vod_settings_handler_test.go    # Handler unit tests
+│   ├── logupload_settings_e2e_test.go  # E2E log upload tests
+│   ├── logupload_settings_handler_test.go # Handler unit tests
+│   ├── logrepo_settings_e2e_test.go    # E2E log repo tests
+│   ├── logrepo_settings_handler_test.go # Handler unit tests
+│   ├── logrepo_settings_service_test.go # Service unit tests
+│   ├── test_page_controller_test.go    # Test page tests
+│   └── test_utils.go                   # Test utilities
+│
+└── Mocks
+    ├── mock_dao.go                     # CachedSimpleDao mock
+    ├── mock_dao_test.go                # Mock DAO tests
+    ├── mock_database_client.go         # DatabaseClient mock
+    ├── mock_database_client_test.go    # Mock client tests
+    ├── mock_distributed_lock.go        # Distributed lock mock
+    ├── mock_distributed_lock_test.go   # Mock lock tests
+    └── test_setup.go                   # Test setup utilities
+```
+
+---
+
+## Database Tables Used
+
+| Table Name | Operations | Entity Type |
+|------------|------------|-------------|
+| `TABLE_DEVICE_SETTINGS` | CRUD | `logupload.DeviceSettings` |
+| `TABLE_VOD_SETTINGS` | CRUD | `logupload.VodSettings` |
+| `TABLE_LOG_UPLOAD_SETTINGS` | CRUD | `logupload.LogUploadSettings` |
+| `TABLE_UPLOAD_REPOSITORY` | CRUD | `logupload.UploadRepository` |
+| `TABLE_DCM_RULES` | CRUD | `logupload.DCMGenericRule` |
+
+---
+
+## Use Cases
+
+### UC-DCM-001: Device Settings Management
+
+**Description**: CRUD operations for device settings configuration.
+
+**Actors**: Admin User
+
+**Preconditions**:
+- User is authenticated
+- User has appropriate permissions
+- Application type cookie is set
+
+**Main Flow**:
+1. **Create**: POST `/xconfAdminService/dcm/deviceSettings`
+   - Validate device settings JSON
+   - Check for duplicate ID
+   - Store in `TABLE_DEVICE_SETTINGS`
+   - Return 201 Created
+
+2. **Read All**: GET `/xconfAdminService/dcm/deviceSettings`
+   - Filter by application type
+   - Return all matching settings
+
+3. **Read One**: GET `/xconfAdminService/dcm/deviceSettings/{id}`
+   - Lookup by ID
+   - Return 404 if not found
+
+4. **Update**: PUT `/xconfAdminService/dcm/deviceSettings`
+   - Validate entity exists
+   - Validate changes
+   - Update in database
+   - Return 200 OK
+
+5. **Delete**: DELETE `/xconfAdminService/dcm/deviceSettings/{id}`
+   - Check entity exists
+   - Check no dependencies
+   - Delete from database
+   - Return 200 OK
+
+**Alternative Flows**:
+- A1: Duplicate ID → Return 409 Conflict
+- A2: Entity not found → Return 404 Not Found
+- A3: Invalid JSON → Return 400 Bad Request
+- A4: Missing auth cookie → Return 401 Unauthorized
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-DCM-001-01 | Create valid device setting | 201 Created | ⚠️ In monolithic test |
+| TC-DCM-001-02 | Create duplicate device setting | 409 Conflict | ⚠️ In monolithic test |
+| TC-DCM-001-03 | Get all device settings | 200 OK + list | ⚠️ In monolithic test |
+| TC-DCM-001-04 | Get device setting by ID | 200 OK + entity | ⚠️ In monolithic test |
+| TC-DCM-001-05 | Get non-existent setting | 404 Not Found | 🔲 Not tested |
+| TC-DCM-001-06 | Update valid device setting | 200 OK | ⚠️ In monolithic test |
+| TC-DCM-001-07 | Update non-existent setting | 404 Not Found | ⚠️ In monolithic test |
+| TC-DCM-001-08 | Delete device setting | 200 OK | ⚠️ In monolithic test |
+| TC-DCM-001-09 | Delete non-existent setting | 404 Not Found | 🔲 Not tested |
+| TC-DCM-001-10 | Missing auth cookie | 401 Unauthorized | 🔲 Not tested |
+
+---
+
+### UC-DCM-002: VOD Settings Management
+
+**Description**: CRUD operations for Video On Demand settings.
+
+**Actors**: Admin User
+
+**Main Flow**:
+1. **Create**: POST `/xconfAdminService/dcm/vodSettings`
+2. **Read All**: GET `/xconfAdminService/dcm/vodSettings`
+3. **Read One**: GET `/xconfAdminService/dcm/vodSettings/{id}`
+4. **Update**: PUT `/xconfAdminService/dcm/vodSettings`
+5. **Delete**: DELETE `/xconfAdminService/dcm/vodSettings/{id}`
+6. **Export**: GET `/xconfAdminService/dcm/vodSettings/export`
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-DCM-002-01 | Create valid VOD setting | 201 Created | ⚠️ In monolithic test |
+| TC-DCM-002-02 | Get VOD settings export | 200 OK + data | ✅ Individual test |
+| TC-DCM-002-03 | Export empty result | 200 OK + empty | ✅ Individual test |
+| TC-DCM-002-04 | Export with DCM formulas | 200 OK + formulas | ✅ Individual test |
+| TC-DCM-002-05 | Export filter by app type | 200 OK + filtered | ✅ Individual test |
+| TC-DCM-002-06 | Export missing VOD settings | 200 OK + partial | ✅ Individual test |
+| TC-DCM-002-07 | Export verify headers | Correct headers | ✅ Individual test |
+| TC-DCM-002-08 | Export missing auth cookie | 401 Unauthorized | ✅ Individual test |
+| TC-DCM-002-09 | Export different app types | Correct filtering | ✅ Individual test |
+| TC-DCM-002-10 | Export multiple formulas | All included | ✅ Individual test |
+| TC-DCM-002-11 | Export validate structure | Valid JSON | ✅ Individual test |
+
+---
+
+### UC-DCM-003: Log Upload Settings Management
+
+**Description**: CRUD operations for log upload configuration.
+
+**Actors**: Admin User
+
+**Main Flow**:
+1. **Create**: POST `/xconfAdminService/dcm/logUploadSettings`
+2. **Read All**: GET `/xconfAdminService/dcm/logUploadSettings`
+3. **Read One**: GET `/xconfAdminService/dcm/logUploadSettings/{id}`
+4. **Update**: PUT `/xconfAdminService/dcm/logUploadSettings`
+5. **Delete**: DELETE `/xconfAdminService/dcm/logUploadSettings/{id}`
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-DCM-003-01 | Create log upload setting | 201 Created | ⚠️ In monolithic test |
+| TC-DCM-003-02 | Get all log upload settings | 200 OK + list | ⚠️ In monolithic test |
+| TC-DCM-003-03 | Get log upload setting by ID | 200 OK + entity | ⚠️ In monolithic test |
+| TC-DCM-003-04 | Update log upload setting | 200 OK | ⚠️ In monolithic test |
+| TC-DCM-003-05 | Delete log upload setting | 200 OK | ⚠️ In monolithic test |
+
+---
+
+### UC-DCM-004: Log Repository Settings Management
+
+**Description**: CRUD operations for upload repository configuration.
+
+**Actors**: Admin User
+
+**Main Flow**:
+1. **Create**: POST `/xconfAdminService/dcm/logRepoSettings`
+2. **Read All**: GET `/xconfAdminService/dcm/logRepoSettings`
+3. **Read One**: GET `/xconfAdminService/dcm/logRepoSettings/{id}`
+4. **Update**: PUT `/xconfAdminService/dcm/logRepoSettings`
+5. **Delete**: DELETE `/xconfAdminService/dcm/logRepoSettings/{id}`
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-DCM-004-01 | Create log repo setting | 201 Created | ⚠️ In monolithic test |
+| TC-DCM-004-02 | Get all log repo settings | 200 OK + list | ⚠️ In monolithic test |
+| TC-DCM-004-03 | Get log repo by ID | 200 OK + entity | ⚠️ In monolithic test |
+| TC-DCM-004-04 | Update log repo setting | 200 OK | ⚠️ In monolithic test |
+| TC-DCM-004-05 | Delete log repo setting | 200 OK | ⚠️ In monolithic test |
+
+---
+
+### UC-DCM-005: DCM Formula Management
+
+**Description**: DCM rule/formula CRUD operations.
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-DCM-005-01 | Create DCM formula | 201 Created | 🔲 Needs test |
+| TC-DCM-005-02 | Get all DCM formulas | 200 OK + list | 🔲 Needs test |
+| TC-DCM-005-03 | Get DCM formula by ID | 200 OK + entity | 🔲 Needs test |
+| TC-DCM-005-04 | Update DCM formula | 200 OK | 🔲 Needs test |
+| TC-DCM-005-05 | Delete DCM formula | 200 OK | 🔲 Needs test |
+
+---
+
+## Current Issues
+
+### Issue DCM-001: Monolithic E2E Tests
+
+**File**: `device_settings_e2e_test.go`
+
+**Current Code**:
+```go
+func TestAllDeviceSettingsApis(t *testing.T) {
+    SkipIfMockDatabase(t)
+    DeleteAllEntities()          // ❌ Clears ALL tables
+    defer DeleteAllEntities()     // ❌ Clears ALL tables
+    
+    // Tests GET ALL, CREATE, CREATE DUPLICATE, UPDATE, GET BY ID, DELETE
+    // All in one function - not idempotent
+}
+```
+
+**Problem**:
+- Single test function does CRUD - cannot run individual tests
+- `DeleteAllEntities()` affects other parallel tests
+- Not idempotent - depends on previous operations
+
+**Solution**:
+```go
+// Split into independent tests
+func TestCreateDeviceSetting(t *testing.T) {
+    id := uuid.New().String()
+    cleanup := createTestDeviceSetting(t, id)
+    defer cleanup()
+    
+    // Test create logic
+}
+
+func TestGetDeviceSettingById(t *testing.T) {
+    id := uuid.New().String()
+    cleanup := createTestDeviceSetting(t, id)
+    defer cleanup()
+    
+    // Test get by ID logic
+}
+```
+
+---
+
+### Issue DCM-002: Double Cleanup Pattern
+
+**File**: `logrepo_settings_service_test.go`
+
+**Current Code**:
+```go
+func TestSomeFunction(t *testing.T) {
+    DeleteAllEntities()           // ❌ Unnecessary
+    defer DeleteAllEntities()      // ❌ Should be surgical
+    
+    // Test logic
+}
+```
+
+**Solution**:
+```go
+func TestSomeFunction(t *testing.T) {
+    id := uuid.New().String()
+    cleanup := createTestEntity(t, id, db.TABLE_UPLOAD_REPOSITORY)
+    defer cleanup()  // ✅ Only deletes what was created
+    
+    // Test logic
+}
+```
+
+---
+
+### Issue DCM-003: TestMain Mock Timing
+
+**File**: `dcmformula_test.go`
+
+**Current Code**:
+```go
+func TestMain(m *testing.M) {
+    // Config loaded
+    // Server created (tries to connect to Cassandra!)
+    // Then mock initialized - TOO LATE
+}
+```
+
+**Solution**:
+```go
+func TestMain(m *testing.M) {
+    // Load config
+    
+    if IsMockDatabaseEnabled() {
+        InitMockDatabase()  // ✅ Initialize mock FIRST
+    }
+    
+    // Now create server (will use mock if enabled)
+    server = oshttp.NewWebconfigServer(...)
+}
+```
+
+---
+
+## Mock Requirements
+
+### MockCachedSimpleDao Methods Needed
+
+| Method | Parameters | Return | Used By |
+|--------|------------|--------|---------|
+| `GetOne` | tableName, rowKey | interface{}, error | All CRUD |
+| `SetOne` | tableName, rowKey, entity | error | Create, Update |
+| `DeleteOne` | tableName, rowKey | error | Delete |
+| `GetAllAsList` | tableName, maxResults | []interface{}, error | List all |
+| `GetAllAsMap` | tableName | map[interface{}]interface{}, error | List as map |
+| `RefreshAll` | tableName | error | Cache refresh |
+
+### Test Data Fixtures
+
+```go
+// Device Settings fixture
+func NewTestDeviceSetting(id string) *logupload.DeviceSettings {
+    return &logupload.DeviceSettings{
+        ID:                id,
+        Name:              "Test_" + id[:8],
+        CheckOnReboot:     true,
+        SettingsAreActive: true,
+        Schedule: logupload.Schedule{
+            Type:       "ActNow",
+            Expression: "26 4 * * *",
+            TimeZone:   "UTC",
+        },
+        ApplicationType: "stb",
+    }
+}
+
+// VOD Settings fixture
+func NewTestVodSettings(id string) *logupload.VodSettings {
+    return &logupload.VodSettings{
+        ID:              id,
+        Name:            "Test_" + id[:8],
+        ApplicationType: "stb",
+    }
+}
+
+// Log Upload Settings fixture
+func NewTestLogUploadSettings(id string) *logupload.LogUploadSettings {
+    return &logupload.LogUploadSettings{
+        ID:              id,
+        Name:            "Test_" + id[:8],
+        ApplicationType: "stb",
+    }
+}
+
+// Upload Repository fixture
+func NewTestUploadRepository(id string) *logupload.UploadRepository {
+    return &logupload.UploadRepository{
+        ID:       id,
+        Name:     "Test_" + id[:8],
+        Protocol: "HTTP",
+        URL:      "http://test.example.com",
+    }
+}
+```
+
+---
+
+## API Endpoints Reference
+
+| Method | Endpoint | Handler | Description |
+|--------|----------|---------|-------------|
+| GET | `/dcm/deviceSettings` | GetAllDeviceSettings | List all device settings |
+| GET | `/dcm/deviceSettings/{id}` | GetDeviceSettingById | Get device setting by ID |
+| POST | `/dcm/deviceSettings` | CreateDeviceSetting | Create device setting |
+| PUT | `/dcm/deviceSettings` | UpdateDeviceSetting | Update device setting |
+| DELETE | `/dcm/deviceSettings/{id}` | DeleteDeviceSetting | Delete device setting |
+| GET | `/dcm/deviceSettings/size` | GetDeviceSettingsSize | Get count |
+| GET | `/dcm/deviceSettings/names` | GetDeviceSettingsNames | Get names list |
+| GET | `/dcm/vodSettings` | GetAllVodSettings | List all VOD settings |
+| GET | `/dcm/vodSettings/{id}` | GetVodSettingById | Get VOD setting by ID |
+| POST | `/dcm/vodSettings` | CreateVodSetting | Create VOD setting |
+| PUT | `/dcm/vodSettings` | UpdateVodSetting | Update VOD setting |
+| DELETE | `/dcm/vodSettings/{id}` | DeleteVodSetting | Delete VOD setting |
+| GET | `/dcm/vodSettings/export` | GetVodSettingsExport | Export VOD settings |
+| GET | `/dcm/logUploadSettings` | GetAllLogUploadSettings | List all log upload settings |
+| GET | `/dcm/logRepoSettings` | GetAllLogRepoSettings | List all log repo settings |
+
+---
+
+## Coverage Goals
+
+| File | Current | Target | Focus Areas |
+|------|---------|--------|-------------|
+| device_settings_handler.go | ~60% | 85% | Error paths, edge cases |
+| device_settings_service.go | ~55% | 85% | Validation, business logic |
+| vod_settings_handler.go | ~70% | 90% | Already well tested |
+| vod_settings_service.go | ~60% | 85% | Validation |
+| logupload_settings_handler.go | ~50% | 85% | All CRUD paths |
+| logrepo_settings_handler.go | ~55% | 85% | All CRUD paths |
+| logrepo_settings_service.go | ~65% | 90% | Business logic |
+| dcmformula_handler.go | ~40% | 80% | CRUD operations |
+
+---
+
+## Dependencies
+
+### Internal Dependencies
+- `common/` - Common structs and utilities
+- `shared/logupload/` - LogUpload types and functions
+- `http/` - WebconfigServer
+
+### External Dependencies
+- `github.com/rdkcentral/xconfwebconfig/db` - Database access
+- `github.com/rdkcentral/xconfwebconfig/shared/logupload` - Core types
+- `github.com/gorilla/mux` - HTTP routing
+
+---
+
+## Test Execution Commands
+
+```bash
+# Run all DCM tests with mock
+USE_MOCK_DB=true go test -v ./adminapi/dcm/... -count=1
+
+# Run specific test
+USE_MOCK_DB=true go test -v ./adminapi/dcm/... -run TestGetVodSettingExportHandler_Success
+
+# Run with coverage
+USE_MOCK_DB=true go test ./adminapi/dcm/... -coverprofile=dcm.out
+go tool cover -func=dcm.out | grep -E "handler|service"
+
+# Run with real DB
+USE_MOCK_DB=false go test -v ./adminapi/dcm/... -count=1 -timeout=5m
+```

--- a/openspec/changes/unit-test-enhancement/specs/mock-infrastructure-spec.md
+++ b/openspec/changes/unit-test-enhancement/specs/mock-infrastructure-spec.md
@@ -1,0 +1,441 @@
+# Mock Infrastructure Specification
+
+## Overview
+
+This document specifies the mock database infrastructure required for dual-mode testing (mock/real DB) across all xconfadmin modules.
+
+---
+
+## Architecture
+
+```
+Mock Infrastructure
+├── Environment Control
+│   └── USE_MOCK_DB environment variable
+│
+├── Mock DAO Layer
+│   ├── MockCachedSimpleDao (exists)
+│   ├── MockSimpleDao (NEW - for GetSimpleDao)
+│   └── MockListingDao (NEW - for GetListingDao)
+│
+├── Mock Database Client
+│   └── MockDatabaseClient (exists)
+│
+├── Mock Distributed Lock
+│   └── MockDistributedLock (exists)
+│
+└── Test Utilities
+    ├── InitMockDatabase()
+    ├── ClearMockDatabase()
+    ├── IsMockDatabaseEnabled()
+    └── createTestEntity() / cleanup functions
+```
+
+---
+
+## DAO Interface Requirements
+
+### 1. CachedSimpleDao Interface (Existing)
+
+**Location**: `adminapi/dcm/mocks/mock_dao.go`
+
+**Used By**: 39 files across all modules
+
+**Required Methods**:
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| GetOne | `(tableName, rowKey string) (interface{}, error)` | Get single entity |
+| GetOneFromCacheOnly | `(tableName, rowKey string) (interface{}, error)` | Get from cache only |
+| SetOne | `(tableName, rowKey string, entity interface{}) error` | Create/Update entity |
+| DeleteOne | `(tableName, rowKey string) error` | Delete entity |
+| GetAllAsList | `(tableName string, maxResults int) ([]interface{}, error)` | List all entities |
+| GetAllAsMap | `(tableName string) (map[interface{}]interface{}, error)` | Get as map |
+| GetAllAsShallowMap | `(tableName string) (map[interface{}]interface{}, error)` | Get shallow map |
+| GetAllByKeys | `(tableName string, rowKeys []string) ([]interface{}, error)` | Get by multiple keys |
+| RefreshAll | `(tableName string) error` | Refresh cache |
+| GetKeys | `(tableName string) ([]string, error)` | Get all keys |
+
+**Implementation Pattern**:
+```go
+type MockCachedSimpleDao struct {
+    data map[string]map[string]interface{} // tableName -> rowKey -> entity
+    mu   sync.RWMutex
+}
+
+func (m *MockCachedSimpleDao) GetOne(tableName, rowKey string) (interface{}, error) {
+    m.mu.RLock()
+    defer m.mu.RUnlock()
+    
+    if m.data[tableName] == nil {
+        return nil, errors.New("not found")
+    }
+    entity, ok := m.data[tableName][rowKey]
+    if !ok {
+        return nil, errors.New("not found")
+    }
+    return entity, nil
+}
+```
+
+---
+
+### 2. SimpleDao Interface (NEW - Needed)
+
+**Location**: `adminapi/dcm/mocks/mock_simple_dao.go` (to create)
+
+**Used By**: `shared/change/change.go`
+
+**Tables**:
+- TABLE_XCONF_CHANGE
+- TABLE_XCONF_APPROVED_CHANGE
+- TABLE_TELEMETRY_CHANGES
+- TABLE_TELEMETRY_APPROVED_CHANGES
+- TABLE_TELEMETRY_TWO_CHANGES
+- TABLE_TELEMETRY_APPROVED_TWO_CHANGES
+
+**Required Methods**:
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| GetOne | `(tableName, rowKey string) (interface{}, error)` | Get entity |
+| SetOne | `(tableName, rowKey string, entity interface{}) error` | Set entity |
+| DeleteOne | `(tableName, rowKey string) error` | Delete entity |
+| GetAllAsList | `(tableName string, maxResults int) ([]interface{}, error)` | List all |
+| GetRange | `(tableName, startKey, endKey string, maxResults int) ([]interface{}, error)` | Range query |
+
+**Implementation Pattern**:
+```go
+type MockSimpleDao struct {
+    data map[string]map[string]interface{}
+    mu   sync.RWMutex
+}
+
+func NewMockSimpleDao() *MockSimpleDao {
+    return &MockSimpleDao{
+        data: make(map[string]map[string]interface{}),
+    }
+}
+
+func (m *MockSimpleDao) GetRange(tableName, startKey, endKey string, maxResults int) ([]interface{}, error) {
+    m.mu.RLock()
+    defer m.mu.RUnlock()
+    
+    var result []interface{}
+    if m.data[tableName] == nil {
+        return result, nil
+    }
+    
+    count := 0
+    for key, entity := range m.data[tableName] {
+        if key >= startKey && key <= endKey {
+            result = append(result, entity)
+            count++
+            if maxResults > 0 && count >= maxResults {
+                break
+            }
+        }
+    }
+    return result, nil
+}
+```
+
+---
+
+### 3. ListingDao Interface (NEW - Needed)
+
+**Location**: `adminapi/dcm/mocks/mock_listing_dao.go` (to create)
+
+**Used By**: `shared/estbfirmware/config_change_logs.go`
+
+**Tables**:
+- TABLE_LOGS
+
+**Required Methods**:
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| SetOne | `(tableName, rowKey string, entity interface{}) error` | Store log entry |
+| GetRange | `(tableName, startKey, endKey string, maxResults int) ([]interface{}, error)` | Get log range |
+| DeleteRange | `(tableName, startKey, endKey string) error` | Delete log range |
+
+**Implementation Pattern**:
+```go
+type MockListingDao struct {
+    data map[string][]interface{} // tableName -> sorted entries
+    mu   sync.RWMutex
+}
+
+func NewMockListingDao() *MockListingDao {
+    return &MockListingDao{
+        data: make(map[string][]interface{}),
+    }
+}
+```
+
+---
+
+## Environment Control
+
+### USE_MOCK_DB Variable
+
+```go
+// Check if mock mode is enabled
+func IsMockDatabaseEnabled() bool {
+    return os.Getenv("USE_MOCK_DB") == "true"
+}
+
+// Skip test if mock mode (for integration tests)
+func SkipIfMockDatabase(t *testing.T) {
+    if IsMockDatabaseEnabled() {
+        t.Skip("Skipping: requires real database (USE_MOCK_DB=true)")
+    }
+}
+
+// Skip test if real DB (for mock-only tests)
+func SkipIfRealDatabase(t *testing.T) {
+    if !IsMockDatabaseEnabled() {
+        t.Skip("Skipping: mock-only test (USE_MOCK_DB=false)")
+    }
+}
+```
+
+---
+
+## Mock Initialization
+
+### TestMain Pattern
+
+```go
+var (
+    mockDao      *mocks.MockCachedSimpleDao
+    mockSimpleDao *mocks.MockSimpleDao
+    mockListingDao *mocks.MockListingDao
+)
+
+func TestMain(m *testing.M) {
+    // Load config
+    testConfigFile = GetTestConfig()
+    sc, _ = xwcommon.NewServerConfig(testConfigFile)
+    
+    // Initialize mock BEFORE server creation
+    if IsMockDatabaseEnabled() {
+        InitMockDatabase()
+    }
+    
+    // Create server (will use mock if enabled)
+    server = oshttp.NewWebconfigServer(sc, false)
+    router = server.GetRouter()
+    
+    // Run tests
+    code := m.Run()
+    
+    os.Exit(code)
+}
+
+func InitMockDatabase() {
+    // Create mock instances
+    mockDao = mocks.NewMockCachedSimpleDao()
+    mockSimpleDao = mocks.NewMockSimpleDao()
+    mockListingDao = mocks.NewMockListingDao()
+    
+    // Register mock DAOs
+    db.SetMockCachedSimpleDao(mockDao)
+    db.SetMockSimpleDao(mockSimpleDao)
+    db.SetMockListingDao(mockListingDao)
+    
+    // Register table configs
+    registerTableConfigs()
+}
+
+func registerTableConfigs() {
+    // DCM tables
+    db.RegisterTableConfigSimple(db.TABLE_DEVICE_SETTINGS, logupload.NewDeviceSettingsInf)
+    db.RegisterTableConfigSimple(db.TABLE_VOD_SETTINGS, logupload.NewVodSettingsInf)
+    db.RegisterTableConfigSimple(db.TABLE_LOG_UPLOAD_SETTINGS, logupload.NewLogUploadSettingsInf)
+    db.RegisterTableConfigSimple(db.TABLE_UPLOAD_REPOSITORY, logupload.NewUploadRepositoryInf)
+    
+    // Queries tables
+    db.RegisterTableConfigSimple(db.TABLE_MODELS, shared.NewModelInf)
+    db.RegisterTableConfigSimple(db.TABLE_ENVIRONMENTS, shared.NewEnvironmentInf)
+    db.RegisterTableConfigSimple(db.TABLE_FIRMWARE_CONFIGS, firmware.NewFirmwareConfigInf)
+    db.RegisterTableConfigSimple(db.TABLE_FIRMWARE_RULES, firmware.NewFirmwareRuleInf)
+    
+    // ... more tables
+}
+
+func ClearMockDatabase() {
+    if mockDao != nil {
+        mockDao.Clear()
+    }
+    if mockSimpleDao != nil {
+        mockSimpleDao.Clear()
+    }
+    if mockListingDao != nil {
+        mockListingDao.Clear()
+    }
+}
+```
+
+---
+
+## Test Utility Functions
+
+### Entity Creation and Cleanup
+
+```go
+// CreateTestEntity creates an entity and returns cleanup function
+func createTestEntity(t *testing.T, entity interface{}, id, tableName string) func() {
+    t.Helper()
+    
+    err := db.GetCachedSimpleDao().SetOne(tableName, id, entity)
+    if err != nil {
+        t.Fatalf("Failed to create test entity: %v", err)
+    }
+    
+    // Return cleanup function
+    return func() {
+        _ = db.GetCachedSimpleDao().DeleteOne(tableName, id)
+    }
+}
+
+// CreateMultipleTestEntities creates multiple entities
+func createMultipleTestEntities(t *testing.T, entities map[string]interface{}, tableName string) func() {
+    t.Helper()
+    
+    for id, entity := range entities {
+        err := db.GetCachedSimpleDao().SetOne(tableName, id, entity)
+        if err != nil {
+            t.Fatalf("Failed to create test entity %s: %v", id, err)
+        }
+    }
+    
+    return func() {
+        for id := range entities {
+            _ = db.GetCachedSimpleDao().DeleteOne(tableName, id)
+        }
+    }
+}
+```
+
+### HTTP Test Helpers
+
+```go
+// ExecuteRequest executes HTTP request and returns response
+func ExecuteRequest(r *http.Request, handler http.Handler) *httptest.ResponseRecorder {
+    recorder := httptest.NewRecorder()
+    handler.ServeHTTP(recorder, r)
+    return recorder
+}
+
+// PerformRequest helper for common test patterns
+func PerformRequest(t *testing.T, method, url string, body []byte, expectedStatus int) *httptest.ResponseRecorder {
+    t.Helper()
+    
+    var req *http.Request
+    var err error
+    
+    if body != nil {
+        req, err = http.NewRequest(method, url, bytes.NewBuffer(body))
+    } else {
+        req, err = http.NewRequest(method, url, nil)
+    }
+    
+    if err != nil {
+        t.Fatalf("Failed to create request: %v", err)
+    }
+    
+    req.Header.Set("Content-Type", "application/json")
+    req.AddCookie(&http.Cookie{Name: "applicationType", Value: "stb"})
+    
+    res := ExecuteRequest(req, router)
+    
+    if res.Code != expectedStatus {
+        t.Errorf("Expected status %d, got %d. Body: %s", expectedStatus, res.Code, res.Body.String())
+    }
+    
+    return res
+}
+```
+
+---
+
+## Table Configuration Map
+
+### Tables by Module
+
+| Module | Tables | DAO Type |
+|--------|--------|----------|
+| DCM | DEVICE_SETTINGS, VOD_SETTINGS, LOG_UPLOAD_SETTINGS, UPLOAD_REPOSITORY, DCM_RULES | CachedSimpleDao |
+| Queries | MODELS, ENVIRONMENTS, FIRMWARE_CONFIGS, FIRMWARE_RULES, NS_LISTS, IP_ADDRESS_GROUPS | CachedSimpleDao |
+| Telemetry | TELEMETRY_PROFILES, TELEMETRY_RULES, TELEMETRY_TWO_PROFILES, TELEMETRY_TWO_RULES | CachedSimpleDao |
+| Change | XCONF_CHANGE, XCONF_APPROVED_CHANGE, TELEMETRY_CHANGES, TELEMETRY_APPROVED_CHANGES | SimpleDao |
+| Setting | SETTING_PROFILES, SETTING_RULES | CachedSimpleDao |
+| RFC | FEATURES, FEATURE_CONTROL_RULES | CachedSimpleDao |
+| Shared/estbfirmware | LOGS | ListingDao |
+| Common | APP_SETTINGS, DCM_RULES, ENVIRONMENTS, MODELS | CachedSimpleDao |
+
+---
+
+## Thread Safety
+
+All mock implementations MUST be thread-safe:
+
+```go
+type MockCachedSimpleDao struct {
+    data map[string]map[string]interface{}
+    mu   sync.RWMutex  // Read/Write mutex for thread safety
+}
+
+// Read operations use RLock
+func (m *MockCachedSimpleDao) GetOne(tableName, rowKey string) (interface{}, error) {
+    m.mu.RLock()
+    defer m.mu.RUnlock()
+    // ...
+}
+
+// Write operations use Lock
+func (m *MockCachedSimpleDao) SetOne(tableName, rowKey string, entity interface{}) error {
+    m.mu.Lock()
+    defer m.mu.Unlock()
+    // ...
+}
+```
+
+---
+
+## Performance Characteristics
+
+| Operation | Mock Time | Real DB Time | Speedup |
+|-----------|-----------|--------------|---------|
+| GetOne | ~1µs | ~10ms | 10,000x |
+| SetOne | ~1µs | ~15ms | 15,000x |
+| DeleteOne | ~1µs | ~10ms | 10,000x |
+| GetAllAsList (100 items) | ~10µs | ~50ms | 5,000x |
+| Full test suite | ~30s | ~15min | 30x |
+
+---
+
+## Files to Create
+
+| File | Purpose | Priority |
+|------|---------|----------|
+| `adminapi/dcm/mocks/mock_simple_dao.go` | SimpleDao mock implementation | P0 |
+| `adminapi/dcm/mocks/mock_simple_dao_test.go` | SimpleDao mock tests | P0 |
+| `adminapi/dcm/mocks/mock_listing_dao.go` | ListingDao mock implementation | P1 |
+| `adminapi/dcm/mocks/mock_listing_dao_test.go` | ListingDao mock tests | P1 |
+
+---
+
+## Verification Commands
+
+```bash
+# Test mock infrastructure
+USE_MOCK_DB=true go test -v ./adminapi/dcm/mocks/... -count=1
+
+# Verify mock works across modules
+USE_MOCK_DB=true go test -v ./adminapi/dcm/... -run "Mock" -count=1
+
+# Full suite with mock
+USE_MOCK_DB=true go test ./... -count=1 -timeout=5m
+```

--- a/openspec/changes/unit-test-enhancement/specs/module-inventory.md
+++ b/openspec/changes/unit-test-enhancement/specs/module-inventory.md
@@ -1,0 +1,333 @@
+# Unit Test Enhancement - Module Inventory
+
+## Overview
+
+Complete inventory of all modules and files requiring enhancement for mock/real DB support.
+
+---
+
+## Modules Summary
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         XCONFADMIN MODULE INVENTORY                          │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  ADMINAPI MODULES (Primary Focus)                                            │
+│  ═══════════════════════════════════════════════════════════════════════     │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────┐    │
+│  │ adminapi/dcm/           │ 21 files │ Has mocks │ Has TestMain │ P0  │    │
+│  │ adminapi/queries/       │ 52 files │ Partial   │ Has TestMain │ P0  │    │
+│  │ adminapi/telemetry/     │ 15 files │ Has mocks │ Has TestMain │ P0  │    │
+│  │ adminapi/change/        │ 12 files │ No mocks  │ Has TestMain │ P1  │    │
+│  │ adminapi/setting/       │  4 files │ No mocks  │ No TestMain  │ P1  │    │
+│  │ adminapi/canary/        │  2 files │ No mocks  │ No TestMain  │ P1  │    │
+│  │ adminapi/rfc/feature/   │  5 files │ No mocks  │ Has TestMain │ P1  │    │
+│  │ adminapi/auth/          │  1 file  │ No mocks  │ No TestMain  │ P1  │    │
+│  │ adminapi/xcrp/          │  2 files │ No mocks  │ No TestMain  │ P2  │    │
+│  │ adminapi/firmware/      │  1 file  │ No mocks  │ No TestMain  │ P2  │    │
+│  │ adminapi/configuration/ │  1 file  │ No mocks  │ No TestMain  │ P2  │    │
+│  └─────────────────────────────────────────────────────────────────────┘    │
+│                                                                              │
+│  TAGGING API MODULES                                                         │
+│  ═══════════════════════════════════════════════════════════════════════     │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────┐    │
+│  │ taggingapi/tag/         │  6 files │ No mocks  │ No TestMain  │ P1  │    │
+│  │ taggingapi/config/      │  1 file  │ No mocks  │ No TestMain  │ P2  │    │
+│  │ taggingapi/percentage/  │  1 file  │ No mocks  │ No TestMain  │ P2  │    │
+│  └─────────────────────────────────────────────────────────────────────┘    │
+│                                                                              │
+│  SHARED MODULES                                                              │
+│  ═══════════════════════════════════════════════════════════════════════     │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────┐    │
+│  │ shared/estbfirmware/    │ 11 files │ No mocks  │ No TestMain  │ P1  │    │
+│  │ shared/firmware/        │  2 files │ No mocks  │ No TestMain  │ P2  │    │
+│  │ shared/logupload/       │  4 files │ No mocks  │ No TestMain  │ P2  │    │
+│  │ shared/rfc/             │  3 files │ No mocks  │ No TestMain  │ P2  │    │
+│  │ shared/change/          │  1 file  │ No mocks  │ No TestMain  │ P2  │    │
+│  │ shared/ (root)          │  5 files │ No mocks  │ No TestMain  │ P2  │    │
+│  └─────────────────────────────────────────────────────────────────────┘    │
+│                                                                              │
+│  HTTP MODULE (Already Has Mocks)                                             │
+│  ═══════════════════════════════════════════════════════════════════════     │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────┐    │
+│  │ http/                   │ 10 files │ Has mocks │ Has TestMain │ P3  │    │
+│  └─────────────────────────────────────────────────────────────────────┘    │
+│                                                                              │
+│  UTILITY MODULES (No DB Access - Out of Scope)                               │
+│  ═══════════════════════════════════════════════════════════════════════     │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────┐    │
+│  │ util/                   │  9 files │ N/A       │ N/A          │ --  │    │
+│  │ common/                 │  4 files │ N/A       │ N/A          │ --  │    │
+│  └─────────────────────────────────────────────────────────────────────┘    │
+│                                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Detailed File Inventory
+
+### adminapi/dcm/ (21 test files)
+
+| File | Type | Has Mock | Idempotent | Cleanup |
+|------|------|----------|------------|---------|
+| `dcmformula_test.go` | Unit/E2E | ✓ | ⚠️ Partial | ⚠️ Double |
+| `device_settings_e2e_test.go` | E2E | ✓ | ❌ Single function | ⚠️ DeleteAll |
+| `device_settings_handler_test.go` | Handler | ✓ | ⚠️ Partial | ⚠️ Partial |
+| `vod_settings_e2e_test.go` | E2E | ✓ | ❌ Single function | ⚠️ DeleteAll |
+| `vod_settings_handler_test.go` | Handler | ✓ | ⚠️ Partial | ⚠️ Partial |
+| `logrepo_settings_e2e_test.go` | E2E | ✓ | ⚠️ Partial | ⚠️ Double |
+| `logrepo_settings_handler_test.go` | Handler | ✓ | ⚠️ Partial | ⚠️ Partial |
+| `logrepo_settings_service_test.go` | Service | ✓ | ⚠️ Partial | ⚠️ Double |
+| `logupload_settings_e2e_test.go` | E2E | ✓ | ⚠️ Partial | ⚠️ DeleteAll |
+| `logupload_settings_handler_test.go` | Handler | ✓ | ⚠️ Partial | ⚠️ Partial |
+| `test_page_controller_test.go` | Controller | ✓ | ⚠️ Partial | ⚠️ Partial |
+| `test_utils.go` | Utils | ✓ | N/A | N/A |
+| `mocks/mock_dao.go` | Mock | ✓ | N/A | N/A |
+| `mocks/mock_dao_test.go` | Test | ✓ | ✓ | ✓ |
+| `mocks/mock_database_client.go` | Mock | ✓ | N/A | N/A |
+| `mocks/mock_database_client_test.go` | Test | ✓ | ✓ | ✓ |
+| `mocks/mock_distributed_lock.go` | Mock | ✓ | N/A | N/A |
+| `mocks/mock_distributed_lock_test.go` | Test | ✓ | ✓ | ✓ |
+| `mocks/test_setup.go` | Utils | ✓ | N/A | N/A |
+
+### adminapi/queries/ (52 test files)
+
+| File | Type | Has Mock | Idempotent | Cleanup |
+|------|------|----------|------------|---------|
+| `model_handler_test.go` | Handler | ⚠️ | ⚠️ | ⚠️ |
+| `model_service_test.go` | Service | ⚠️ | ⚠️ | ⚠️ |
+| `model_test.go` | Unit | ⚠️ | ⚠️ | ⚠️ |
+| `model_query_update_delete_test.go` | Mixed | ⚠️ | ❌ | ⚠️ |
+| `firmware_config_handler_test.go` | Handler | ⚠️ | ⚠️ | ⚠️ |
+| `firmware_config_service_test.go` | Service | ⚠️ | ⚠️ | ⚠️ |
+| `firmware_config_test.go` | Unit | ⚠️ | ⚠️ | ⚠️ |
+| `firmware_rule_handler_test.go` | Handler | ⚠️ | ⚠️ | ⚠️ |
+| `firmware_rule_service_test.go` | Service | ⚠️ | ⚠️ | ⚠️ |
+| `firmware_rule_test.go` | Unit | ⚠️ | ⚠️ | ⚠️ |
+| `firmware_rule_template_handler_test.go` | Handler | ⚠️ | ⚠️ | ⚠️ |
+| `firmware_rule_template_handler_additional_test.go` | Handler | ⚠️ | ⚠️ | ⚠️ |
+| `firmware_rule_template_service_test.go` | Service | ⚠️ | ⚠️ | ⚠️ |
+| `firmware_rule_report_page_handler_test.go` | Handler | ⚠️ | ⚠️ | ⚠️ |
+| `feature_entity_handler_test.go` | Handler | ⚠️ | ⚠️ | ⚠️ |
+| `feature_entity_service_test.go` | Service | ⚠️ | ⚠️ | ⚠️ |
+| `feature_rule_handler_test.go` | Handler | ⚠️ | ⚠️ | ⚠️ |
+| `feature_rule_service_test.go` | Service | ⚠️ | ⚠️ | ⚠️ |
+| `feature_service_test.go` | Service | ⚠️ | ⚠️ | ⚠️ |
+| `ip_address_group_service_test.go` | Service | ⚠️ | ⚠️ | ⚠️ |
+| `ipaddressgroup_maclist_handlers_test.go` | Handler | ⚠️ | ⚠️ | ⚠️ |
+| `mac_rule_bean_handler_test.go` | Handler | ⚠️ | ⚠️ | ⚠️ |
+| `maclist_test.go` | Unit | ⚠️ | ⚠️ | ⚠️ |
+| `ips_filter_service_test.go` | Service | ⚠️ | ⚠️ | ⚠️ |
+| `location_filter_service_test.go` | Service | ⚠️ | ⚠️ | ⚠️ |
+| `percent_filter_service_test.go` | Service | ⚠️ | ⚠️ | ⚠️ |
+| `percentfilter_handler_test.go` | Handler | ⚠️ | ⚠️ | ⚠️ |
+| `ri_filter_service_test.go` | Service | ⚠️ | ⚠️ | ⚠️ |
+| `time_filter_service_test.go` | Service | ⚠️ | ⚠️ | ⚠️ |
+| `namespaced_list_handler_test.go` | Handler | ⚠️ | ⚠️ | ⚠️ |
+| `namespaced_list_service_test.go` | Service | ⚠️ | ⚠️ | ⚠️ |
+| `environment_handler_test.go` | Handler | ⚠️ | ⚠️ | ⚠️ |
+| `environment_service_test.go` | Service | ⚠️ | ⚠️ | ⚠️ |
+| `percentage_bean_service_test.go` | Service | ⚠️ | ⚠️ | ⚠️ |
+| `percentagebean_handler_test.go` | Handler | ⚠️ | ⚠️ | ⚠️ |
+| `amv_handler_test.go` | Handler | ⚠️ | ⚠️ | ⚠️ |
+| `amv_service_test.go` | Service | ⚠️ | ⚠️ | ⚠️ |
+| `amv_test.go` | Unit | ⚠️ | ⚠️ | ⚠️ |
+| `activation_minimum_version_handler_test.go` | Handler | ⚠️ | ⚠️ | ⚠️ |
+| `log_controller_test.go` | Controller | ⚠️ | ⚠️ | ⚠️ |
+| `log_file_handler_test.go` | Handler | ⚠️ | ⚠️ | ⚠️ |
+| `base_queries_controller_test.go` | Controller | ⚠️ | ⚠️ | ⚠️ |
+| `baserule_validator_test.go` | Validator | ⚠️ | ⚠️ | ⚠️ |
+| `common_test.go` | Common | ⚠️ | ⚠️ | ⚠️ |
+| `converter_test.go` | Converter | ⚠️ | ⚠️ | ⚠️ |
+| `queries_handler_test.go` | Handler | ⚠️ | ⚠️ | ⚠️ |
+| `queries_helper_test.go` | Helper | ⚠️ | ⚠️ | ⚠️ |
+| `queries_test.go` | Unit | ⚠️ | ⚠️ | ⚠️ |
+| `additional_handler_test.go` | Handler | ⚠️ | ⚠️ | ⚠️ |
+| `additional_service_test.go` | Service | ⚠️ | ⚠️ | ⚠️ |
+| `coverage_improvement_test.go` | Coverage | ⚠️ | ⚠️ | ⚠️ |
+| `test_utils.go` | Utils | ✓ | N/A | N/A |
+
+### adminapi/telemetry/ (15 files)
+
+| File | Type | Has Mock | Idempotent | Cleanup |
+|------|------|----------|------------|---------|
+| `telemetry_profile_controller_test.go` | Controller | ✓ | ⚠️ | ⚠️ |
+| `telemetry_profile_handler_test.go` | Handler | ✓ | ⚠️ | ⚠️ |
+| `telemetry_profile_service_test.go` | Service | ✓ | ⚠️ | ⚠️ |
+| `telemetry_rule_handler_test.go` | Handler | ✓ | ⚠️ | ⚠️ |
+| `telemetry_v2_rule_service_test.go` | Service | ✓ | ⚠️ | ⚠️ |
+| `telemetry_two_dao_test.go` | DAO | ✓ | ⚠️ | ⚠️ |
+| `telemetry_two_loguploader_handler_test.go` | Handler | ✓ | ⚠️ | ⚠️ |
+| `telemetry_two_profile_handler_test.go` | Handler | ✓ | ⚠️ | ⚠️ |
+| `telemetry_two_rule_hanlder_test.go` | Handler | ✓ | ⚠️ | ⚠️ |
+| `test_utils.go` | Utils | ✓ | N/A | N/A |
+
+### adminapi/change/ (12 files)
+
+| File | Type | Has Mock | Idempotent | Cleanup |
+|------|------|----------|------------|---------|
+| `change_handler_test.go` | Handler | ❌ | ⚠️ | ⚠️ |
+| `change_service_test.go` | Service | ❌ | ⚠️ | ⚠️ |
+| `telemetry_profile_handler_test.go` | Handler | ❌ | ⚠️ | ⚠️ |
+| `telemetry_two_change_handler_test.go` | Handler | ❌ | ⚠️ | ⚠️ |
+| `telemetry_two_change_service_test.go` | Service | ❌ | ⚠️ | ⚠️ |
+| `telemetry_two_profile_handler_test.go` | Handler | ❌ | ⚠️ | ⚠️ |
+
+### adminapi/setting/ (4 files)
+
+| File | Type | Has Mock | Idempotent | Cleanup |
+|------|------|----------|------------|---------|
+| `setting_profile_controller_test.go` | Controller | ❌ | ⚠️ | ⚠️ |
+| `setting_profile_service_test.go` | Service | ❌ | ⚠️ | ⚠️ |
+| `setting_rule_controller_test.go` | Controller | ❌ | ⚠️ | ⚠️ |
+| `setting_rule_service_test.go` | Service | ❌ | ⚠️ | ⚠️ |
+
+### adminapi/canary/ (2 files) - NO DIRECT DB
+
+| File | Type | Has Mock | Idempotent | Cleanup |
+|------|------|----------|------------|---------|
+| `canary_settings_handler_test.go` | Handler | N/A | ⚠️ | ⚠️ |
+| `canary_settings_service_test.go` | Service | N/A | ⚠️ | ⚠️ |
+
+**Note**: No direct DB calls. May need TestMain if depends on other DB-using packages.
+
+### adminapi/rfc/feature/ (5 files)
+
+| File | Type | Has Mock | Idempotent | Cleanup |
+|------|------|----------|------------|---------|
+| `feature_handler_test.go` | Handler | ❌ | ⚠️ | ⚠️ |
+| `feature_control_settings_test.go` | Settings | ❌ | ⚠️ | ⚠️ |
+| `feature_test_helpers_test.go` | Helper | ❌ | ⚠️ | ⚠️ |
+
+### adminapi/auth/ (1 file)
+
+| File | Type | Has Mock | Idempotent | Cleanup |
+|------|------|----------|------------|---------|
+| `idp_service_handler_test.go` | Handler | ❌ | ⚠️ | ⚠️ |
+
+### adminapi/xcrp/ (2 files)
+
+| File | Type | Has Mock | Idempotent | Cleanup |
+|------|------|----------|------------|---------|
+| `recooking_lockdown_settings_handler_test.go` | Handler | ❌ | ⚠️ | ⚠️ |
+| `recooking_status_handler_test.go` | Handler | ❌ | ⚠️ | ⚠️ |
+
+### adminapi/firmware/ (1 file)
+
+| File | Type | Has Mock | Idempotent | Cleanup |
+|------|------|----------|------------|---------|
+| `firmware_test_page_controller_test.go` | Controller | ❌ | ⚠️ | ⚠️ |
+
+### adminapi/configuration/ip-macrule/ (1 file)
+
+| File | Type | Has Mock | Idempotent | Cleanup |
+|------|------|----------|------------|---------|
+| `ip_mac_ruleconfig_handler_test.go` | Handler | ❌ | ⚠️ | ⚠️ |
+
+### taggingapi/tag/ (6 files)
+
+| File | Type | Has Mock | Idempotent | Cleanup |
+|------|------|----------|------------|---------|
+| `tag_handler_test.go` | Handler | ❌ | ⚠️ | ⚠️ |
+| `tag_member_service_test.go` | Service | ❌ | ⚠️ | ⚠️ |
+| `tag_normalization_service_test.go` | Service | ❌ | ⚠️ | ⚠️ |
+| `tag_service_test.go` | Service | ❌ | ⚠️ | ⚠️ |
+| `tag_member_benchmark_test.go` | Benchmark | ❌ | ⚠️ | ⚠️ |
+
+### taggingapi/config/ (1 file)
+
+| File | Type | Has Mock | Idempotent | Cleanup |
+|------|------|----------|------------|---------|
+| `tag_config_test.go` | Config | ❌ | ⚠️ | ⚠️ |
+
+### taggingapi/percentage/ (1 file)
+
+| File | Type | Has Mock | Idempotent | Cleanup |
+|------|------|----------|------------|---------|
+| `percentage_service_test.go` | Service | ❌ | ⚠️ | ⚠️ |
+
+### shared/estbfirmware/ (11 files)
+
+| File | Type | Has Mock | Idempotent | Cleanup |
+|------|------|----------|------------|---------|
+| `estb_firmware_context_test.go` | Context | ❌ | ⚠️ | ⚠️ |
+| `config_change_logs_test.go` | Logs | ❌ | ⚠️ | ⚠️ |
+| `singleton_filter_test.go` | Filter | ❌ | ⚠️ | ⚠️ |
+| `time_filter_test.go` | Filter | ❌ | ⚠️ | ⚠️ |
+| `estbfirmware_unit_test.go` | Unit | ❌ | ⚠️ | ⚠️ |
+| `percent_filter_test.go` | Filter | ❌ | ⚠️ | ⚠️ |
+| `estb_converters_test.go` | Converter | ❌ | ⚠️ | ⚠️ |
+| `ip_filter_test.go` | Filter | ❌ | ⚠️ | ⚠️ |
+| `reboot_immediately_filter_test.go` | Filter | ❌ | ⚠️ | ⚠️ |
+| `firmware_config_test.go` | Config | ❌ | ⚠️ | ⚠️ |
+
+### shared/firmware/ (2 files)
+
+| File | Type | Has Mock | Idempotent | Cleanup |
+|------|------|----------|------------|---------|
+| `firmwarerule_test.go` | Rule | ❌ | ⚠️ | ⚠️ |
+| `firmware_unit_test.go` | Unit | ❌ | ⚠️ | ⚠️ |
+
+### shared/logupload/ (4 files)
+
+| File | Type | Has Mock | Idempotent | Cleanup |
+|------|------|----------|------------|---------|
+| `utils_test.go` | Utils | ❌ | ⚠️ | ⚠️ |
+| `permanent_profile_test.go` | Profile | ❌ | ⚠️ | ⚠️ |
+| `logupload_test.go` | Unit | ❌ | ⚠️ | ⚠️ |
+| `telemetry_profile_test.go` | Profile | ❌ | ⚠️ | ⚠️ |
+
+### shared/rfc/ (3 files)
+
+| File | Type | Has Mock | Idempotent | Cleanup |
+|------|------|----------|------------|---------|
+| `feature_rule_test.go` | Rule | ❌ | ⚠️ | ⚠️ |
+| `feature_test.go` | Feature | ❌ | ⚠️ | ⚠️ |
+| `feature_predicate_test.go` | Predicate | ❌ | ⚠️ | ⚠️ |
+
+### shared/change/ (1 file)
+
+| File | Type | Has Mock | Idempotent | Cleanup |
+|------|------|----------|------------|---------|
+| `change_test.go` | Change | ❌ | ⚠️ | ⚠️ |
+
+### shared/ (root - 5 files)
+
+| File | Type | Has Mock | Idempotent | Cleanup |
+|------|------|----------|------------|---------|
+| `coretypes_test.go` | CoreTypes | ❌ | ⚠️ | ⚠️ |
+| `coretypes_clone_test.go` | Clone | ❌ | ⚠️ | ⚠️ |
+| `coretypes_additional_test.go` | Additional | ❌ | ⚠️ | ⚠️ |
+| `percentage_service_test.go` | Service | ❌ | ⚠️ | ⚠️ |
+| `percentage_service_extra_test.go` | Service | ❌ | ⚠️ | ⚠️ |
+
+---
+
+## Legend
+
+| Symbol | Meaning |
+|--------|---------|
+| ✓ | Complete/Present |
+| ❌ | Missing/Not Present |
+| ⚠️ | Partial/Needs Review |
+| N/A | Not Applicable |
+
+---
+
+## Statistics
+
+| Category | Count |
+|----------|-------|
+| Total Test Files | 157 |
+| Files with Mock Support | ~25 |
+| Files Needing Mock Infrastructure | ~132 |
+| New test_utils.go Files Needed | ~15 |
+| Files with Double Cleanup Issue | ~20+ |
+| Files with DeleteAllEntities | ~30+ |

--- a/openspec/changes/unit-test-enhancement/specs/queries-module-spec.md
+++ b/openspec/changes/unit-test-enhancement/specs/queries-module-spec.md
@@ -1,0 +1,458 @@
+# Queries Module Specification
+
+## Module Overview
+
+**Package**: `adminapi/queries/`  
+**Priority**: P0 - Critical  
+**Status**: Partial mocks, largest module requiring enhancement
+
+The Queries module is the largest module in xconfadmin, handling firmware rules, models, environments, filters, namespaced lists, and various configuration entities.
+
+---
+
+## Architecture
+
+```
+adminapi/queries/
+├── Core Handlers
+│   ├── queries_handler.go           # Main query handlers
+│   ├── queries_helper.go            # Query helper functions
+│   ├── base_queries_controller.go   # Base controller logic
+│   └── queries_test.go              # TestMain, shared setup
+│
+├── Model Management
+│   ├── model_handler.go             # Model CRUD handlers
+│   ├── model_handler_test.go        # Model handler tests
+│   ├── model_service.go             # Model business logic
+│   ├── model_service_test.go        # Model service tests
+│   ├── model_test.go                # Model unit tests
+│   └── model_query_update_delete_test.go
+│
+├── Environment Management
+│   ├── environment_handler.go       # Environment CRUD
+│   ├── environment_handler_test.go
+│   ├── environment_service.go
+│   └── environment_service_test.go
+│
+├── Firmware Configuration
+│   ├── firmware_config_handler.go
+│   ├── firmware_config_handler_test.go
+│   ├── firmware_config_service.go
+│   ├── firmware_config_service_test.go
+│   └── firmware_config_test.go
+│
+├── Firmware Rules
+│   ├── firmware_rule_handler.go
+│   ├── firmware_rule_handler_test.go
+│   ├── firmware_rule_service.go
+│   ├── firmware_rule_service_test.go
+│   ├── firmware_rule_test.go
+│   ├── firmware_rule_template_handler.go
+│   ├── firmware_rule_template_handler_test.go
+│   ├── firmware_rule_template_handler_additional_test.go
+│   └── firmware_rule_template_service_test.go
+│
+├── Feature Management
+│   ├── feature_handler.go
+│   ├── feature_entity_handler_test.go
+│   ├── feature_entity_service_test.go
+│   ├── feature_rule_handler_test.go
+│   ├── feature_rule_service_test.go
+│   └── feature_service_test.go
+│
+├── IP/MAC Address Management
+│   ├── ip_address_group_handler.go
+│   ├── ip_address_group_service_test.go
+│   ├── ipaddressgroup_maclist_handlers_test.go
+│   ├── mac_rule_bean_handler.go
+│   ├── mac_rule_bean_handler_test.go
+│   └── maclist_test.go
+│
+├── Filters
+│   ├── ips_filter_handler.go
+│   ├── ips_filter_service_test.go
+│   ├── location_filter_handler.go
+│   ├── location_filter_service_test.go
+│   ├── percent_filter_handler.go
+│   ├── percent_filter_service_test.go
+│   ├── percentfilter_handler_test.go
+│   ├── ri_filter_handler.go
+│   ├── ri_filter_service_test.go
+│   ├── time_filter_handler.go
+│   └── time_filter_service_test.go
+│
+├── Namespaced Lists
+│   ├── namespaced_list_handler.go
+│   ├── namespaced_list_handler_test.go
+│   ├── namespaced_list_service.go
+│   └── namespaced_list_service_test.go
+│
+├── Percentage Beans
+│   ├── percentage_bean_handler.go
+│   ├── percentage_bean_service_test.go
+│   └── percentagebean_handler_test.go
+│
+├── AMV (Activation Minimum Version)
+│   ├── amv_handler.go
+│   ├── amv_handler_test.go
+│   ├── amv_service.go
+│   ├── amv_service_test.go
+│   ├── amv_test.go
+│   └── activation_minimum_version_handler_test.go
+│
+└── Supporting Files
+    ├── converter.go
+    ├── converter_test.go
+    ├── common.go
+    ├── common_test.go
+    ├── baserule_validator_test.go
+    ├── log_controller_test.go
+    ├── log_file_handler_test.go
+    └── various additional tests...
+```
+
+---
+
+## Database Tables Used
+
+| Table Name | Operations | Entity Type |
+|------------|------------|-------------|
+| `TABLE_MODELS` | CRUD | `shared.Model` |
+| `TABLE_ENVIRONMENTS` | CRUD | `shared.Environment` |
+| `TABLE_FIRMWARE_CONFIGS` | CRUD | `firmware.FirmwareConfig` |
+| `TABLE_FIRMWARE_RULES` | CRUD | `firmware.FirmwareRule` |
+| `TABLE_FIRMWARE_RULE_TEMPLATES` | CRUD | `firmware.FirmwareRuleTemplate` |
+| `TABLE_FEATURES` | CRUD | `rfc.Feature` |
+| `TABLE_FEATURE_CONTROL_RULES` | CRUD | `rfc.FeatureRule` |
+| `TABLE_IP_ADDRESS_GROUPS` | CRUD | `shared.IpAddressGroup` |
+| `TABLE_MAC_LISTS` | CRUD | `shared.MacList` |
+| `TABLE_NS_LISTS` | CRUD | `shared.NamespacedList` |
+| `TABLE_SINGLETON_FILTER_VALUE` | CRUD | Filter values |
+| `TABLE_PERCENT_FILTER` | CRUD | `estbfirmware.PercentFilter` |
+
+---
+
+## Use Cases
+
+### UC-QUERIES-001: Model Management
+
+**Description**: CRUD operations for device models.
+
+**API Endpoints**:
+- GET `/queries/models` - List all models
+- GET `/queries/models/{id}` - Get model by ID
+- POST `/queries/models` - Create model
+- PUT `/queries/models` - Update model
+- DELETE `/queries/models/{id}` - Delete model
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-QRY-001-01 | Create valid model | 201 Created | ⚠️ Needs refactor |
+| TC-QRY-001-02 | Create duplicate model | 409 Conflict | ⚠️ Needs refactor |
+| TC-QRY-001-03 | Get all models | 200 OK + list | ⚠️ Needs refactor |
+| TC-QRY-001-04 | Get model by ID | 200 OK + entity | ⚠️ Needs refactor |
+| TC-QRY-001-05 | Get non-existent model | 404 Not Found | 🔲 Not tested |
+| TC-QRY-001-06 | Update model | 200 OK | ⚠️ Needs refactor |
+| TC-QRY-001-07 | Delete model | 200 OK | ⚠️ Needs refactor |
+| TC-QRY-001-08 | Delete model with references | 409 Conflict | 🔲 Not tested |
+
+---
+
+### UC-QUERIES-002: Environment Management
+
+**Description**: CRUD operations for environments.
+
+**API Endpoints**:
+- GET `/queries/environments` - List all environments
+- GET `/queries/environments/{id}` - Get by ID
+- POST `/queries/environments` - Create
+- PUT `/queries/environments` - Update
+- DELETE `/queries/environments/{id}` - Delete
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-QRY-002-01 | Create environment | 201 Created | ⚠️ Needs refactor |
+| TC-QRY-002-02 | Get all environments | 200 OK + list | ⚠️ Needs refactor |
+| TC-QRY-002-03 | Get environment by ID | 200 OK + entity | ⚠️ Needs refactor |
+| TC-QRY-002-04 | Update environment | 200 OK | ⚠️ Needs refactor |
+| TC-QRY-002-05 | Delete environment | 200 OK | ⚠️ Needs refactor |
+| TC-QRY-002-06 | Delete with references | 409 Conflict | 🔲 Not tested |
+
+---
+
+### UC-QUERIES-003: Firmware Configuration
+
+**Description**: CRUD operations for firmware configurations.
+
+**API Endpoints**:
+- GET `/queries/firmwareConfigs` - List all
+- GET `/queries/firmwareConfigs/{id}` - Get by ID
+- POST `/queries/firmwareConfigs` - Create
+- PUT `/queries/firmwareConfigs` - Update
+- DELETE `/queries/firmwareConfigs/{id}` - Delete
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-QRY-003-01 | Create firmware config | 201 Created | ⚠️ Needs refactor |
+| TC-QRY-003-02 | Create duplicate | 409 Conflict | 🔲 Not tested |
+| TC-QRY-003-03 | Get all configs | 200 OK + list | ⚠️ Needs refactor |
+| TC-QRY-003-04 | Get config by ID | 200 OK + entity | ⚠️ Needs refactor |
+| TC-QRY-003-05 | Update config | 200 OK | ⚠️ Needs refactor |
+| TC-QRY-003-06 | Delete config | 200 OK | ⚠️ Needs refactor |
+| TC-QRY-003-07 | Delete with rules | 409 Conflict | 🔲 Not tested |
+
+---
+
+### UC-QUERIES-004: Firmware Rules
+
+**Description**: CRUD operations for firmware rules and templates.
+
+**API Endpoints**:
+- GET `/queries/rules` - List all rules
+- GET `/queries/rules/{id}` - Get rule by ID
+- POST `/queries/rules` - Create rule
+- PUT `/queries/rules` - Update rule
+- DELETE `/queries/rules/{id}` - Delete rule
+- GET `/queries/rules/templates` - List templates
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-QRY-004-01 | Create firmware rule | 201 Created | ⚠️ Needs refactor |
+| TC-QRY-004-02 | Create rule with invalid model | 400 Bad Request | 🔲 Not tested |
+| TC-QRY-004-03 | Get all rules | 200 OK + list | ⚠️ Needs refactor |
+| TC-QRY-004-04 | Get rule by ID | 200 OK + entity | ⚠️ Needs refactor |
+| TC-QRY-004-05 | Update rule | 200 OK | ⚠️ Needs refactor |
+| TC-QRY-004-06 | Delete rule | 200 OK | ⚠️ Needs refactor |
+| TC-QRY-004-07 | Create rule template | 201 Created | ⚠️ Needs refactor |
+| TC-QRY-004-08 | Apply template | 200 OK | 🔲 Not tested |
+
+---
+
+### UC-QUERIES-005: Namespaced Lists
+
+**Description**: CRUD operations for namespaced lists (IP lists, MAC lists, etc.).
+
+**API Endpoints**:
+- GET `/queries/namespacedLists` - List all
+- GET `/queries/namespacedLists/{id}` - Get by ID
+- POST `/queries/namespacedLists` - Create
+- PUT `/queries/namespacedLists` - Update
+- DELETE `/queries/namespacedLists/{id}` - Delete
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-QRY-005-01 | Create namespaced list | 201 Created | ⚠️ Needs refactor |
+| TC-QRY-005-02 | Get all lists | 200 OK + list | ⚠️ Needs refactor |
+| TC-QRY-005-03 | Get list by ID | 200 OK + entity | ⚠️ Needs refactor |
+| TC-QRY-005-04 | Update list | 200 OK | ⚠️ Needs refactor |
+| TC-QRY-005-05 | Delete list | 200 OK | ⚠️ Needs refactor |
+| TC-QRY-005-06 | Delete with references | 409 Conflict | 🔲 Not tested |
+
+---
+
+### UC-QUERIES-006: Filters
+
+**Description**: Manage various filter types (IP, location, time, percent, RI).
+
+**API Endpoints**:
+- GET/POST/PUT/DELETE `/queries/filters/ips`
+- GET/POST/PUT/DELETE `/queries/filters/location`
+- GET/POST/PUT/DELETE `/queries/filters/time`
+- GET/POST/PUT/DELETE `/queries/filters/percent`
+- GET/POST/PUT/DELETE `/queries/filters/ri`
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-QRY-006-01 | Create IP filter | 201 Created | ⚠️ Needs refactor |
+| TC-QRY-006-02 | Create location filter | 201 Created | ⚠️ Needs refactor |
+| TC-QRY-006-03 | Create time filter | 201 Created | ⚠️ Needs refactor |
+| TC-QRY-006-04 | Create percent filter | 201 Created | ⚠️ Needs refactor |
+| TC-QRY-006-05 | Create RI filter | 201 Created | ⚠️ Needs refactor |
+
+---
+
+### UC-QUERIES-007: Percentage Beans
+
+**Description**: Manage percentage distribution configurations.
+
+**API Endpoints**:
+- GET `/queries/percentageBeans` - List all
+- POST `/queries/percentageBeans` - Create
+- PUT `/queries/percentageBeans` - Update
+- DELETE `/queries/percentageBeans/{id}` - Delete
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-QRY-007-01 | Create percentage bean | 201 Created | ⚠️ Needs refactor |
+| TC-QRY-007-02 | Get all beans | 200 OK + list | ⚠️ Needs refactor |
+| TC-QRY-007-03 | Update bean | 200 OK | ⚠️ Needs refactor |
+| TC-QRY-007-04 | Delete bean | 200 OK | ⚠️ Needs refactor |
+| TC-QRY-007-05 | Validate percentages sum | 400 if >100% | 🔲 Not tested |
+
+---
+
+### UC-QUERIES-008: AMV (Activation Minimum Version)
+
+**Description**: Manage activation minimum version rules.
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-QRY-008-01 | Create AMV rule | 201 Created | ⚠️ Needs refactor |
+| TC-QRY-008-02 | Get all AMV rules | 200 OK + list | ⚠️ Needs refactor |
+| TC-QRY-008-03 | Update AMV rule | 200 OK | ⚠️ Needs refactor |
+| TC-QRY-008-04 | Delete AMV rule | 200 OK | ⚠️ Needs refactor |
+
+---
+
+## Current Issues
+
+### Issue QUERIES-001: TestMain Shared State
+
+**File**: `queries_test.go`
+
+**Problem**: TestMain creates global server instance used by all tests.
+
+**Solution**:
+```go
+func TestMain(m *testing.M) {
+    if IsMockDatabaseEnabled() {
+        InitMockDatabase()  // Initialize mock before server
+    }
+    
+    // Create server (uses mock if enabled)
+    server = oshttp.NewWebconfigServer(...)
+    
+    code := m.Run()
+    os.Exit(code)
+}
+```
+
+---
+
+### Issue QUERIES-002: Large Test Files
+
+**Problem**: Some test files have 50+ test functions with shared setup.
+
+**Solution**: 
+- Group related tests in subtests
+- Use table-driven tests
+- Each test creates and cleans up own data
+
+---
+
+## Test Data Fixtures
+
+```go
+// Model fixture
+func NewTestModel(id string) *shared.Model {
+    return &shared.Model{
+        ID:          id,
+        Description: "Test Model " + id[:8],
+    }
+}
+
+// Environment fixture
+func NewTestEnvironment(id string) *shared.Environment {
+    return &shared.Environment{
+        ID:          id,
+        Description: "Test Environment " + id[:8],
+    }
+}
+
+// Firmware Config fixture
+func NewTestFirmwareConfig(id string) *firmware.FirmwareConfig {
+    return &firmware.FirmwareConfig{
+        ID:               id,
+        Description:      "Test Config " + id[:8],
+        FirmwareFilename: "test.bin",
+        FirmwareVersion:  "1.0.0",
+    }
+}
+
+// Firmware Rule fixture
+func NewTestFirmwareRule(id, modelId string) *firmware.FirmwareRule {
+    return &firmware.FirmwareRule{
+        ID:              id,
+        Name:            "Test Rule " + id[:8],
+        Type:            "MODEL_RULE",
+        ApplicationType: "stb",
+        Rule: shared.Rule{
+            Condition: shared.Condition{
+                FreeArg: shared.FreeArg{
+                    Type: "STRING",
+                    Name: "model",
+                },
+                Operation: "IS",
+                FixedArg: shared.FixedArg{
+                    Bean: shared.Bean{
+                        Value: shared.Value{
+                            Java_class: "java.lang.String",
+                            Value:      modelId,
+                        },
+                    },
+                },
+            },
+        },
+    }
+}
+
+// Namespaced List fixture
+func NewTestNamespacedList(id string) *shared.NamespacedList {
+    return &shared.NamespacedList{
+        ID:   id,
+        Type: "MAC_LIST",
+        Data: []string{"AA:BB:CC:DD:EE:FF"},
+    }
+}
+```
+
+---
+
+## Coverage Goals
+
+| Area | Files | Current | Target |
+|------|-------|---------|--------|
+| Model | 3 | ~60% | 85% |
+| Environment | 2 | ~55% | 85% |
+| Firmware Config | 3 | ~50% | 85% |
+| Firmware Rules | 6 | ~45% | 80% |
+| Features | 5 | ~55% | 85% |
+| Filters | 6 | ~50% | 80% |
+| Namespaced Lists | 2 | ~60% | 85% |
+| Percentage Beans | 2 | ~55% | 85% |
+| AMV | 4 | ~50% | 80% |
+
+---
+
+## Test Execution Commands
+
+```bash
+# Run all queries tests with mock
+USE_MOCK_DB=true go test -v ./adminapi/queries/... -count=1 -timeout=5m
+
+# Run specific test file
+USE_MOCK_DB=true go test -v ./adminapi/queries/... -run "Model" -count=1
+
+# Run with coverage
+USE_MOCK_DB=true go test ./adminapi/queries/... -coverprofile=queries.out
+go tool cover -func=queries.out | head -50
+
+# Generate HTML coverage report
+go tool cover -html=queries.out -o queries_coverage.html
+```

--- a/openspec/changes/unit-test-enhancement/specs/shared-modules-spec.md
+++ b/openspec/changes/unit-test-enhancement/specs/shared-modules-spec.md
@@ -1,0 +1,430 @@
+# Shared Modules Specification
+
+## Overview
+
+The `shared/` package contains shared business logic, entity types, and utility functions used across multiple modules.
+
+---
+
+## Module Structure
+
+```
+shared/
+├── Root Level
+│   ├── coretypes.go                    # Core type definitions
+│   ├── coretypes_test.go
+│   ├── coretypes_clone_test.go
+│   ├── coretypes_additional_test.go
+│   ├── percentage_service.go           # Percentage calculations
+│   ├── percentage_service_test.go
+│   └── percentage_service_extra_test.go
+│
+├── estbfirmware/                        # ESTB firmware logic
+│   ├── firmware_config.go
+│   ├── firmware_config_test.go
+│   ├── config_change_logs.go           # Uses GetListingDao!
+│   ├── config_change_logs_test.go
+│   ├── estb_firmware_context.go
+│   ├── estb_firmware_context_test.go
+│   ├── estb_converters.go
+│   ├── estb_converters_test.go
+│   ├── singleton_filter.go
+│   ├── singleton_filter_test.go
+│   ├── time_filter.go
+│   ├── time_filter_test.go
+│   ├── percent_filter.go
+│   ├── percent_filter_test.go
+│   ├── ip_filter.go
+│   ├── ip_filter_test.go
+│   ├── reboot_immediately_filter.go
+│   ├── reboot_immediately_filter_test.go
+│   └── estbfirmware_unit_test.go
+│
+├── firmware/                            # Firmware types
+│   ├── firmwarerule.go
+│   ├── firmwarerule_test.go
+│   └── firmware_unit_test.go
+│
+├── logupload/                           # Log upload types
+│   ├── logupload.go
+│   ├── logupload_test.go
+│   ├── telemetry_profile.go
+│   ├── telemetry_profile_test.go
+│   ├── permanent_profile.go
+│   ├── permanent_profile_test.go
+│   └── utils_test.go
+│
+├── rfc/                                 # RFC/Feature types
+│   ├── feature.go
+│   ├── feature_test.go
+│   ├── feature_rule.go
+│   ├── feature_rule_test.go
+│   └── feature_predicate_test.go
+│
+└── change/                              # Change types
+    ├── change.go                        # Uses GetSimpleDao!
+    └── change_test.go
+```
+
+---
+
+## DAO Usage Summary
+
+| Package | File | DAO Type | Tables |
+|---------|------|----------|--------|
+| shared/estbfirmware | config_change_logs.go | **GetListingDao** | TABLE_LOGS |
+| shared/estbfirmware | firmware_config.go | GetCachedSimpleDao | TABLE_FIRMWARE_CONFIGS |
+| shared/estbfirmware | singleton_filter.go | GetCachedSimpleDao | TABLE_SINGLETON_FILTER_VALUE |
+| shared/estbfirmware | percent_filter.go | GetCachedSimpleDao | TABLE_PERCENT_FILTER |
+| shared/estbfirmware | ip_filter.go | GetCachedSimpleDao | TABLE_IP_FILTER |
+| shared/firmware | firmwarerule.go | GetCachedSimpleDao | TABLE_FIRMWARE_RULES |
+| shared/logupload | logupload.go | GetCachedSimpleDao | TABLE_LOG_FILES, TABLE_LOG_FILE_GROUPS |
+| shared/logupload | telemetry_profile.go | GetCachedSimpleDao | TABLE_TELEMETRY_* |
+| shared/rfc | feature.go | GetCachedSimpleDao | TABLE_FEATURES, TABLE_FEATURE_CONTROL_RULES |
+| shared/change | change.go | **GetSimpleDao** | TABLE_XCONF_CHANGE, TABLE_TELEMETRY_* |
+
+---
+
+## shared/estbfirmware/ Specification
+
+### config_change_logs.go
+
+**CRITICAL**: Uses `GetListingDao()` - needs MockListingDao!
+
+```go
+// Current usage
+db.GetListingDao().SetOne(db.TABLE_LOGS, key, logEntry)
+db.GetListingDao().GetRange(db.TABLE_LOGS, startKey, endKey, maxResults)
+```
+
+**Tables**: TABLE_LOGS
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-ESTB-001 | Write log entry | Success | 🔲 Needs mock |
+| TC-ESTB-002 | Get log range | Log entries | 🔲 Needs mock |
+| TC-ESTB-003 | Empty range | Empty list | 🔲 Needs mock |
+
+### Filter Types
+
+| Filter | Table | Entity |
+|--------|-------|--------|
+| SingletonFilter | TABLE_SINGLETON_FILTER_VALUE | SingletonFilterValue |
+| PercentFilter | TABLE_PERCENT_FILTER | PercentFilter |
+| IpFilter | TABLE_IP_FILTER | IpFilter |
+| TimeFilter | TABLE_TIME_FILTER | TimeFilter |
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-FLT-001 | Apply singleton filter | Filtered result | ⚠️ Needs refactor |
+| TC-FLT-002 | Apply percent filter | Percent match | ⚠️ Needs refactor |
+| TC-FLT-003 | Apply IP filter | IP match | ⚠️ Needs refactor |
+| TC-FLT-004 | Apply time filter | Time match | ⚠️ Needs refactor |
+
+---
+
+## shared/firmware/ Specification
+
+### firmwarerule.go
+
+**Tables**: TABLE_FIRMWARE_RULES
+
+**Functions**:
+- `GetFirmwareRule(id string)` - Get rule by ID
+- `GetAllFirmwareRules()` - Get all rules
+- `SetFirmwareRule(rule)` - Create/update rule
+- `DeleteFirmwareRule(id)` - Delete rule
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-FW-001 | Get firmware rule | Rule entity | ⚠️ Needs mock |
+| TC-FW-002 | Get all rules | Rule list | ⚠️ Needs mock |
+| TC-FW-003 | Set firmware rule | Success | ⚠️ Needs mock |
+| TC-FW-004 | Delete rule | Success | ⚠️ Needs mock |
+
+---
+
+## shared/logupload/ Specification
+
+### logupload.go
+
+**Tables**: 
+- TABLE_LOG_FILES
+- TABLE_LOG_FILE_GROUPS
+
+**Functions**:
+- `SetLogFile(id, logFile)` - Store log file
+- `GetAllLogFileGroups(size)` - Get log file groups
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-LOG-001 | Set log file | Success | ⚠️ Needs mock |
+| TC-LOG-002 | Get log file groups | Group list | ⚠️ Needs mock |
+
+### telemetry_profile.go
+
+**Tables**:
+- TABLE_PERMANENT_TELEMETRY_PROFILES
+- TABLE_TELEMETRY_TWO_PROFILES
+- TABLE_TELEMETRY_PROFILES
+- TABLE_TELEMETRY_RULES
+- TABLE_TELEMETRY_TWO_RULES
+
+**Functions**:
+- `SetPermanentTelemetryProfile(id, profile)` - Store profile
+- `DeletePermanentTelemetryProfile(id)` - Delete profile
+- `GetAllPermanentTelemetryProfiles()` - Get all profiles
+- `GetAllTelemetryTwoProfiles()` - Get v2 profiles
+- `GetOneTelemetryTwoProfile(id)` - Get v2 profile by ID
+- `SetOneTelemetryTwoProfile(profile)` - Store v2 profile
+- `DeleteOneTelemetryTwoProfile(id)` - Delete v2 profile
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-TEL-001 | Set permanent profile | Success | ⚠️ Needs mock |
+| TC-TEL-002 | Get all permanent | Profile list | ⚠️ Needs mock |
+| TC-TEL-003 | Set v2 profile | Success | ⚠️ Needs mock |
+| TC-TEL-004 | Get v2 profile | Profile entity | ⚠️ Needs mock |
+| TC-TEL-005 | Delete v2 profile | Success | ⚠️ Needs mock |
+
+---
+
+## shared/rfc/ Specification
+
+### feature.go
+
+**Tables**:
+- TABLE_FEATURES
+- TABLE_FEATURE_CONTROL_RULES
+
+**Functions**:
+- `GetAllFeatures()` - Get all features
+- `DeleteFeature(id)` - Delete feature
+- `SetFeature(feature)` - Create/update feature
+- `GetFeatureRule(id)` - Get feature rule
+- `SetFeatureRule(id, rule)` - Set feature rule
+- `DeleteFeatureRule(id)` - Delete feature rule
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-RFC-001 | Get all features | Feature list | ⚠️ Needs mock |
+| TC-RFC-002 | Set feature | Success | ⚠️ Needs mock |
+| TC-RFC-003 | Delete feature | Success | ⚠️ Needs mock |
+| TC-RFC-004 | Get feature rule | Rule entity | ⚠️ Needs mock |
+| TC-RFC-005 | Set feature rule | Success | ⚠️ Needs mock |
+| TC-RFC-006 | Delete feature rule | Success | ⚠️ Needs mock |
+
+---
+
+## shared/change/ Specification
+
+### change.go
+
+**CRITICAL**: Uses `GetSimpleDao()` NOT `GetCachedSimpleDao()`!
+
+**Tables**:
+- TABLE_XCONF_CHANGE
+- TABLE_XCONF_APPROVED_CHANGE
+- TABLE_TELEMETRY_CHANGES
+- TABLE_TELEMETRY_APPROVED_CHANGES
+- TABLE_TELEMETRY_TWO_CHANGES
+- TABLE_TELEMETRY_APPROVED_TWO_CHANGES
+
+**Functions**:
+- `GetChange(id)` - Get change by ID
+- `GetAllPendingChanges()` - Get all pending
+- `CreateChange(change)` - Create change
+- `ApproveChange(id)` - Approve change
+- `RejectChange(id)` - Reject change
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-CHG-001 | Get change | Change entity | 🔲 Needs SimpleDao mock |
+| TC-CHG-002 | Get all pending | Change list | 🔲 Needs SimpleDao mock |
+| TC-CHG-003 | Create change | Success | 🔲 Needs SimpleDao mock |
+| TC-CHG-004 | Approve change | Success | 🔲 Needs SimpleDao mock |
+| TC-CHG-005 | Reject change | Success | 🔲 Needs SimpleDao mock |
+
+---
+
+## Files to Create
+
+### shared/estbfirmware/test_utils.go
+
+```go
+package estbfirmware
+
+import (
+    "os"
+    "testing"
+    "github.com/rdkcentral/xconfadmin/adminapi/dcm/mocks"
+)
+
+var mockDao *mocks.MockCachedSimpleDao
+var mockListingDao *mocks.MockListingDao
+
+func IsMockDatabaseEnabled() bool {
+    return os.Getenv("USE_MOCK_DB") == "true"
+}
+
+func InitMockDatabase() {
+    mockDao = mocks.NewMockCachedSimpleDao()
+    mockListingDao = mocks.NewMockListingDao()
+    db.SetMockCachedSimpleDao(mockDao)
+    db.SetMockListingDao(mockListingDao)
+}
+
+func ClearMockDatabase() {
+    if mockDao != nil {
+        mockDao.Clear()
+    }
+    if mockListingDao != nil {
+        mockListingDao.Clear()
+    }
+}
+```
+
+### shared/firmware/test_utils.go
+
+```go
+package firmware
+
+// Same pattern as above
+```
+
+### shared/logupload/test_utils.go
+
+```go
+package logupload
+
+// Same pattern as above
+```
+
+### shared/rfc/test_utils.go
+
+```go
+package rfc
+
+// Same pattern as above
+```
+
+### shared/change/test_utils.go
+
+```go
+package change
+
+import (
+    "os"
+    "testing"
+    "github.com/rdkcentral/xconfadmin/adminapi/dcm/mocks"
+)
+
+var mockSimpleDao *mocks.MockSimpleDao
+
+func IsMockDatabaseEnabled() bool {
+    return os.Getenv("USE_MOCK_DB") == "true"
+}
+
+func InitMockDatabase() {
+    mockSimpleDao = mocks.NewMockSimpleDao()
+    db.SetMockSimpleDao(mockSimpleDao)
+}
+
+func ClearMockDatabase() {
+    if mockSimpleDao != nil {
+        mockSimpleDao.Clear()
+    }
+}
+```
+
+---
+
+## Test Data Fixtures
+
+```go
+// Firmware Rule fixture
+func NewTestFirmwareRule(id string) *firmware.FirmwareRule {
+    return &firmware.FirmwareRule{
+        ID:              id,
+        Name:            "Test_Rule_" + id[:8],
+        Type:            "MODEL_RULE",
+        ApplicationType: "stb",
+    }
+}
+
+// Feature fixture
+func NewTestFeature(id string) *rfc.Feature {
+    return &rfc.Feature{
+        ID:          id,
+        Name:        "Test_Feature_" + id[:8],
+        FeatureName: "test.feature." + id[:8],
+        Effective:   true,
+    }
+}
+
+// Feature Rule fixture
+func NewTestFeatureRule(id string, featureIds []string) *rfc.FeatureRule {
+    return &rfc.FeatureRule{
+        Id:              id,
+        Name:            "Test_FeatureRule_" + id[:8],
+        FeatureIds:      featureIds,
+        ApplicationType: "stb",
+    }
+}
+
+// Log Entry fixture
+func NewTestLogEntry(key string) *estbfirmware.ConfigChangeLog {
+    return &estbfirmware.ConfigChangeLog{
+        Key:       key,
+        Timestamp: time.Now().UnixMilli(),
+        Message:   "Test log entry",
+    }
+}
+```
+
+---
+
+## Coverage Goals
+
+| Package | Current | Target | Priority |
+|---------|---------|--------|----------|
+| shared/estbfirmware | ~55% | 85% | P1 |
+| shared/firmware | ~50% | 85% | P2 |
+| shared/logupload | ~60% | 85% | P2 |
+| shared/rfc | ~55% | 85% | P2 |
+| shared/change | ~45% | 85% | P2 |
+| shared/ (root) | ~65% | 85% | P2 |
+
+---
+
+## Test Execution Commands
+
+```bash
+# Run all shared module tests
+USE_MOCK_DB=true go test -v ./shared/... -count=1
+
+# Run specific package
+USE_MOCK_DB=true go test -v ./shared/estbfirmware/... -count=1
+USE_MOCK_DB=true go test -v ./shared/firmware/... -count=1
+USE_MOCK_DB=true go test -v ./shared/logupload/... -count=1
+USE_MOCK_DB=true go test -v ./shared/rfc/... -count=1
+USE_MOCK_DB=true go test -v ./shared/change/... -count=1
+
+# Run with coverage
+USE_MOCK_DB=true go test ./shared/... -coverprofile=shared.out
+go tool cover -func=shared.out
+```

--- a/openspec/changes/unit-test-enhancement/specs/supporting-modules-spec.md
+++ b/openspec/changes/unit-test-enhancement/specs/supporting-modules-spec.md
@@ -1,0 +1,461 @@
+# Supporting Modules Specification
+
+## Overview
+
+This document covers the remaining modules that require test enhancement:
+- Setting Module
+- RFC/Feature Module
+- Canary Module
+- Auth Module
+- XCRP Module
+- Firmware Module
+- Configuration IP-MacRule Module
+- Tagging API Module
+- Common Package
+
+---
+
+## Setting Module
+
+**Package**: `adminapi/setting/`  
+**Priority**: P1 - High  
+**Status**: No mocks, no TestMain
+
+### Architecture
+
+```
+adminapi/setting/
+├── setting_profile_controller.go
+├── setting_profile_controller_test.go
+├── setting_profile_service.go
+├── setting_profile_service_test.go
+├── setting_rule_controller.go
+├── setting_rule_controller_test.go
+├── setting_rule_service.go
+└── setting_rule_service_test.go
+```
+
+### Database Tables
+
+| Table | Operations | Entity |
+|-------|------------|--------|
+| TABLE_SETTING_PROFILES | CRUD | `logupload.SettingProfile` |
+| TABLE_SETTING_RULES | CRUD | `logupload.SettingRule` |
+
+### Use Cases
+
+| ID | Use Case | Description |
+|----|----------|-------------|
+| UC-SET-001 | Setting Profile CRUD | Create/Read/Update/Delete profiles |
+| UC-SET-002 | Setting Rule CRUD | Create/Read/Update/Delete rules |
+
+### Test Scenarios
+
+| ID | Scenario | Expected | Status |
+|----|----------|----------|--------|
+| TC-SET-001 | Create setting profile | 201 Created | ⚠️ Needs mock |
+| TC-SET-002 | Get all profiles | 200 OK + list | ⚠️ Needs mock |
+| TC-SET-003 | Create setting rule | 201 Created | ⚠️ Needs mock |
+| TC-SET-004 | Get all rules | 200 OK + list | ⚠️ Needs mock |
+
+### Files to Create
+
+- `adminapi/setting/test_utils.go`
+
+---
+
+## RFC/Feature Module
+
+**Package**: `adminapi/rfc/feature/`  
+**Priority**: P1 - High  
+**Status**: Has TestMain, needs mock enhancement
+
+### Architecture
+
+```
+adminapi/rfc/feature/
+├── feature_handler.go
+├── feature_handler_test.go           # Has TestMain
+├── feature_control_settings.go
+├── feature_control_settings_test.go
+├── feature_test_helpers.go
+└── feature_test_helpers_test.go
+```
+
+### Database Tables
+
+| Table | Operations | Entity |
+|-------|------------|--------|
+| TABLE_FEATURES | CRUD | `rfc.Feature` |
+| TABLE_FEATURE_CONTROL_RULES | CRUD | `rfc.FeatureRule` |
+
+### Use Cases
+
+| ID | Use Case | Description |
+|----|----------|-------------|
+| UC-RFC-001 | Feature CRUD | Manage features |
+| UC-RFC-002 | Feature Rule CRUD | Manage feature rules |
+| UC-RFC-003 | Feature Control Settings | Configure feature controls |
+
+### Test Scenarios
+
+| ID | Scenario | Expected | Status |
+|----|----------|----------|--------|
+| TC-RFC-001 | Create feature | 201 Created | ⚠️ Needs refactor |
+| TC-RFC-002 | Get all features | 200 OK + list | ⚠️ Needs refactor |
+| TC-RFC-003 | Create feature rule | 201 Created | ⚠️ Needs refactor |
+| TC-RFC-004 | Get feature rule | 200 OK + entity | ⚠️ Needs refactor |
+
+### Files to Create
+
+- `adminapi/rfc/feature/test_utils.go`
+
+---
+
+## Canary Module
+
+**Package**: `adminapi/canary/`  
+**Priority**: P1 - High  
+**Status**: No mocks, no TestMain
+
+### Architecture
+
+```
+adminapi/canary/
+├── canary_settings_handler.go
+├── canary_settings_handler_test.go
+├── canary_settings_service.go
+└── canary_settings_service_test.go
+```
+
+### Database Tables
+
+| Table | Operations | Entity |
+|-------|------------|--------|
+| TABLE_CANARY_SETTINGS | CRUD | Canary settings |
+
+### Use Cases
+
+| ID | Use Case | Description |
+|----|----------|-------------|
+| UC-CAN-001 | Canary Settings CRUD | Manage canary deployment settings |
+
+### Test Scenarios
+
+| ID | Scenario | Expected | Status |
+|----|----------|----------|--------|
+| TC-CAN-001 | Create canary setting | 201 Created | ⚠️ Needs mock |
+| TC-CAN-002 | Get canary settings | 200 OK + list | ⚠️ Needs mock |
+| TC-CAN-003 | Update canary setting | 200 OK | ⚠️ Needs mock |
+| TC-CAN-004 | Delete canary setting | 200 OK | ⚠️ Needs mock |
+
+### Files to Create
+
+- `adminapi/canary/test_utils.go`
+
+---
+
+## Auth Module
+
+**Package**: `adminapi/auth/`  
+**Priority**: P1 - High  
+**Status**: No mocks, panics without DB
+
+### Architecture
+
+```
+adminapi/auth/
+├── idp_service_handler.go
+└── idp_service_handler_test.go
+```
+
+### Current Issue
+
+Tests panic without real DB because WebconfigServer initialization requires DB connection.
+
+### Test Scenarios
+
+| ID | Scenario | Expected | Status |
+|----|----------|----------|--------|
+| TC-AUTH-001 | IDP service call | Valid response | ⚠️ Needs mock |
+| TC-AUTH-002 | Invalid token | 401 Unauthorized | ⚠️ Needs mock |
+
+### Files to Create
+
+- `adminapi/auth/test_utils.go`
+
+---
+
+## XCRP Module
+
+**Package**: `adminapi/xcrp/`  
+**Priority**: P2 - Medium  
+**Status**: No mocks, no TestMain
+
+### Architecture
+
+```
+adminapi/xcrp/
+├── recooking_lockdown_settings_handler.go
+├── recooking_lockdown_settings_handler_test.go
+├── recooking_status_handler.go
+└── recooking_status_handler_test.go
+```
+
+### Use Cases
+
+| ID | Use Case | Description |
+|----|----------|-------------|
+| UC-XCRP-001 | Recooking Lockdown | Manage lockdown settings |
+| UC-XCRP-002 | Recooking Status | Check recooking status |
+
+### Test Scenarios
+
+| ID | Scenario | Expected | Status |
+|----|----------|----------|--------|
+| TC-XCRP-001 | Get lockdown settings | 200 OK | ⚠️ Needs mock |
+| TC-XCRP-002 | Set lockdown | 200 OK | ⚠️ Needs mock |
+| TC-XCRP-003 | Get recooking status | 200 OK | ⚠️ Needs mock |
+
+### Files to Create
+
+- `adminapi/xcrp/test_utils.go`
+
+---
+
+## Firmware Module
+
+**Package**: `adminapi/firmware/`  
+**Priority**: P2 - Medium  
+**Status**: No mocks, no TestMain
+
+### Architecture
+
+```
+adminapi/firmware/
+├── firmware_test_page_controller.go
+└── firmware_test_page_controller_test.go
+```
+
+### Use Cases
+
+| ID | Use Case | Description |
+|----|----------|-------------|
+| UC-FW-001 | Firmware Test Page | Test firmware configuration |
+
+### Test Scenarios
+
+| ID | Scenario | Expected | Status |
+|----|----------|----------|--------|
+| TC-FW-001 | Load test page | 200 OK | ⚠️ Needs mock |
+| TC-FW-002 | Test firmware config | Valid result | ⚠️ Needs mock |
+
+### Files to Create
+
+- `adminapi/firmware/test_utils.go`
+
+---
+
+## Configuration IP-MacRule Module
+
+**Package**: `adminapi/configuration/ip-macrule/`  
+**Priority**: P2 - Medium  
+**Status**: No mocks, no TestMain
+
+### Architecture
+
+```
+adminapi/configuration/ip-macrule/
+├── ip_mac_ruleconfig_handler.go
+└── ip_mac_ruleconfig_handler_test.go
+```
+
+### Use Cases
+
+| ID | Use Case | Description |
+|----|----------|-------------|
+| UC-CFG-001 | IP-MAC Rule Config | Configure IP/MAC rules |
+
+### Test Scenarios
+
+| ID | Scenario | Expected | Status |
+|----|----------|----------|--------|
+| TC-CFG-001 | Get IP-MAC rule config | 200 OK | ⚠️ Needs mock |
+| TC-CFG-002 | Set IP-MAC rule config | 200 OK | ⚠️ Needs mock |
+
+### Files to Create
+
+- `adminapi/configuration/ip-macrule/test_utils.go`
+
+---
+
+## Tagging API Module
+
+**Package**: `taggingapi/`  
+**Priority**: P1 - High  
+**Status**: No mocks, no TestMain
+
+### Architecture
+
+```
+taggingapi/
+├── router.go
+├── config/
+│   ├── tag_config.go
+│   └── tag_config_test.go
+├── percentage/
+│   ├── percentage_service.go
+│   └── percentage_service_test.go
+└── tag/
+    ├── tag_handler.go
+    ├── tag_handler_test.go
+    ├── tag_service.go
+    ├── tag_service_test.go
+    ├── tag_member_service.go
+    ├── tag_member_service_test.go
+    ├── tag_normalization_service.go
+    ├── tag_normalization_service_test.go
+    └── tag_member_benchmark_test.go
+```
+
+### Database Tables
+
+| Table | Operations | Entity |
+|-------|------------|--------|
+| TABLE_TAGS | CRUD | `tag.Tag` |
+| TABLE_TAG_MEMBERS | CRUD | `tag.TagMember` |
+
+### Use Cases
+
+| ID | Use Case | Description |
+|----|----------|-------------|
+| UC-TAG-001 | Tag Management | Create/manage tags |
+| UC-TAG-002 | Tag Member Management | Manage tag members |
+| UC-TAG-003 | Tag Normalization | Normalize tag names |
+| UC-TAG-004 | Percentage Service | Calculate percentages |
+
+### Test Scenarios
+
+| ID | Scenario | Expected | Status |
+|----|----------|----------|--------|
+| TC-TAG-001 | Create tag | 201 Created | ⚠️ Needs mock |
+| TC-TAG-002 | Get all tags | 200 OK + list | ⚠️ Needs mock |
+| TC-TAG-003 | Add tag member | 200 OK | ⚠️ Needs mock |
+| TC-TAG-004 | Get tag members | 200 OK + list | ⚠️ Needs mock |
+| TC-TAG-005 | Normalize tag | Normalized name | ⚠️ Needs mock |
+| TC-TAG-006 | Calculate percentage | Valid percentage | ⚠️ Needs mock |
+
+### Files to Create
+
+- `taggingapi/tag/test_utils.go`
+- `taggingapi/config/test_utils.go`
+- `taggingapi/percentage/test_utils.go`
+
+---
+
+## Common Package
+
+**Package**: `common/`  
+**Priority**: P1 - High  
+**Status**: Uses DB extensively, no test_utils.go
+
+### Architecture
+
+```
+common/
+├── const_var.go
+├── const_var_test.go
+├── error.go
+├── error_test.go
+├── server_config.go
+├── server_config_test.go
+├── struct.go                  # Uses GetCachedSimpleDao!
+└── struct_test.go
+```
+
+### Database Tables Used in struct.go
+
+| Table | Operations | Entity |
+|-------|------------|--------|
+| TABLE_APP_SETTINGS | CRUD | `common.ApplicationSetting` |
+| TABLE_DCM_RULES | Read | `logupload.DCMGenericRule` |
+| TABLE_ENVIRONMENTS | CRUD | `shared.Environment` |
+| TABLE_MODELS | CRUD | `shared.Model` |
+
+### Use Cases
+
+| ID | Use Case | Description |
+|----|----------|-------------|
+| UC-CMN-001 | App Settings | Manage application settings |
+| UC-CMN-002 | Get DCM Rules | Retrieve DCM rules |
+| UC-CMN-003 | Environment CRUD | Manage environments |
+| UC-CMN-004 | Model CRUD | Manage models |
+
+### Test Scenarios
+
+| ID | Scenario | Expected | Status |
+|----|----------|----------|--------|
+| TC-CMN-001 | Set app setting | Success | ⚠️ Needs mock |
+| TC-CMN-002 | Get app setting | Setting value | ⚠️ Needs mock |
+| TC-CMN-003 | Get all DCM rules | Rule list | ⚠️ Needs mock |
+| TC-CMN-004 | Get environment | Environment | ⚠️ Needs mock |
+| TC-CMN-005 | Set environment | Success | ⚠️ Needs mock |
+| TC-CMN-006 | Get model | Model | ⚠️ Needs mock |
+| TC-CMN-007 | Set model | Success | ⚠️ Needs mock |
+
+### Files to Create
+
+- `common/test_utils.go`
+
+---
+
+## Summary of Files to Create
+
+| Module | File | Priority |
+|--------|------|----------|
+| adminapi/setting | test_utils.go | P1 |
+| adminapi/rfc/feature | test_utils.go | P1 |
+| adminapi/canary | test_utils.go | P1 |
+| adminapi/auth | test_utils.go | P1 |
+| adminapi/xcrp | test_utils.go | P2 |
+| adminapi/firmware | test_utils.go | P2 |
+| adminapi/configuration/ip-macrule | test_utils.go | P2 |
+| taggingapi/tag | test_utils.go | P1 |
+| taggingapi/config | test_utils.go | P2 |
+| taggingapi/percentage | test_utils.go | P2 |
+| common | test_utils.go | P1 |
+
+**Total**: 11 test_utils.go files to create
+
+---
+
+## Test Execution Commands
+
+```bash
+# Setting module
+USE_MOCK_DB=true go test -v ./adminapi/setting/... -count=1
+
+# RFC module
+USE_MOCK_DB=true go test -v ./adminapi/rfc/... -count=1
+
+# Canary module
+USE_MOCK_DB=true go test -v ./adminapi/canary/... -count=1
+
+# Auth module
+USE_MOCK_DB=true go test -v ./adminapi/auth/... -count=1
+
+# XCRP module
+USE_MOCK_DB=true go test -v ./adminapi/xcrp/... -count=1
+
+# Firmware module
+USE_MOCK_DB=true go test -v ./adminapi/firmware/... -count=1
+
+# Configuration module
+USE_MOCK_DB=true go test -v ./adminapi/configuration/... -count=1
+
+# Tagging API
+USE_MOCK_DB=true go test -v ./taggingapi/... -count=1
+
+# Common package
+USE_MOCK_DB=true go test -v ./common/... -count=1
+```

--- a/openspec/changes/unit-test-enhancement/specs/telemetry-module-spec.md
+++ b/openspec/changes/unit-test-enhancement/specs/telemetry-module-spec.md
@@ -1,0 +1,323 @@
+# Telemetry Module Specification
+
+## Module Overview
+
+**Package**: `adminapi/telemetry/`  
+**Priority**: P0 - Critical  
+**Status**: Has mocks, needs idempotent refactoring
+
+The Telemetry module handles telemetry profiles, telemetry rules, and telemetry two (v2) configurations.
+
+---
+
+## Architecture
+
+```
+adminapi/telemetry/
+├── Telemetry Profiles (v1)
+│   ├── telemetry_profile_handler.go
+│   ├── telemetry_profile_handler_test.go    # TestMain here
+│   ├── telemetry_profile_controller.go
+│   ├── telemetry_profile_controller_test.go
+│   ├── telemetry_profile_service.go
+│   └── telemetry_profile_service_test.go
+│
+├── Telemetry Rules (v1)
+│   ├── telemetry_rule_handler.go
+│   ├── telemetry_rule_handler_test.go
+│   └── telemetry_v2_rule_service_test.go
+│
+└── Telemetry Two (v2)
+    ├── telemetry_two_loguploader_handler.go
+    ├── telemetry_two_loguploader_handler_test.go
+    ├── telemetry_two_profile_handler.go
+    ├── telemetry_two_profile_handler_test.go
+    ├── telemetry_two_rule_handler.go
+    ├── telemetry_two_rule_hanlder_test.go
+    └── telemetry_two_dao_test.go
+```
+
+---
+
+## Database Tables Used
+
+| Table Name | Operations | Entity Type | Version |
+|------------|------------|-------------|---------|
+| `TABLE_TELEMETRY_PROFILES` | Read/Write | `logupload.TelemetryProfile` | v1 |
+| `TABLE_TELEMETRY_RULES` | CRUD | `logupload.TelemetryRule` | v1 |
+| `TABLE_PERMANENT_TELEMETRY_PROFILES` | CRUD | `logupload.PermanentTelemetryProfile` | v1 |
+| `TABLE_TELEMETRY_TWO_PROFILES` | CRUD | `logupload.TelemetryTwoProfile` | v2 |
+| `TABLE_TELEMETRY_TWO_RULES` | CRUD | `logupload.TelemetryTwoRule` | v2 |
+| `TABLE_TELEMETRY_CHANGES` | CRUD | `change.Change` | Change mgmt |
+| `TABLE_TELEMETRY_APPROVED_CHANGES` | CRUD | `change.Change` | Change mgmt |
+| `TABLE_TELEMETRY_TWO_CHANGES` | CRUD | `change.Change` | v2 changes |
+| `TABLE_TELEMETRY_APPROVED_TWO_CHANGES` | CRUD | `change.Change` | v2 changes |
+
+---
+
+## Use Cases
+
+### UC-TEL-001: Telemetry Profile Management (v1)
+
+**Description**: CRUD operations for telemetry profiles.
+
+**API Endpoints**:
+- GET `/telemetry/profile` - List all profiles
+- GET `/telemetry/profile/{id}` - Get profile by ID
+- POST `/telemetry/profile` - Create profile
+- PUT `/telemetry/profile` - Update profile
+- DELETE `/telemetry/profile/{id}` - Delete profile
+- GET `/telemetry/profile/export` - Export profiles
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-TEL-001-01 | Create telemetry profile | 201 Created | ⚠️ Needs refactor |
+| TC-TEL-001-02 | Create duplicate profile | 409 Conflict | ⚠️ Needs refactor |
+| TC-TEL-001-03 | Get all profiles | 200 OK + list | ⚠️ Needs refactor |
+| TC-TEL-001-04 | Get profile by ID | 200 OK + entity | ⚠️ Needs refactor |
+| TC-TEL-001-05 | Get non-existent profile | 404 Not Found | 🔲 Not tested |
+| TC-TEL-001-06 | Update profile | 200 OK | ⚠️ Needs refactor |
+| TC-TEL-001-07 | Delete profile | 200 OK | ⚠️ Needs refactor |
+| TC-TEL-001-08 | Delete profile with rules | 409 Conflict | 🔲 Not tested |
+| TC-TEL-001-09 | Export profiles | 200 OK + data | ⚠️ Needs refactor |
+| TC-TEL-001-10 | Export by app type | Filtered data | 🔲 Not tested |
+
+---
+
+### UC-TEL-002: Telemetry Rules Management (v1)
+
+**Description**: CRUD operations for telemetry rules.
+
+**API Endpoints**:
+- GET `/telemetry/rule` - List all rules
+- GET `/telemetry/rule/{id}` - Get rule by ID
+- POST `/telemetry/rule` - Create rule
+- PUT `/telemetry/rule` - Update rule
+- DELETE `/telemetry/rule/{id}` - Delete rule
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-TEL-002-01 | Create telemetry rule | 201 Created | ⚠️ Needs refactor |
+| TC-TEL-002-02 | Create rule with invalid profile | 400 Bad Request | 🔲 Not tested |
+| TC-TEL-002-03 | Get all rules | 200 OK + list | ⚠️ Needs refactor |
+| TC-TEL-002-04 | Get rule by ID | 200 OK + entity | ⚠️ Needs refactor |
+| TC-TEL-002-05 | Update rule | 200 OK | ⚠️ Needs refactor |
+| TC-TEL-002-06 | Delete rule | 200 OK | ⚠️ Needs refactor |
+
+---
+
+### UC-TEL-003: Telemetry Two Profile Management (v2)
+
+**Description**: CRUD operations for Telemetry 2.0 profiles.
+
+**API Endpoints**:
+- GET `/telemetry/v2/profile` - List all v2 profiles
+- GET `/telemetry/v2/profile/{id}` - Get v2 profile by ID
+- POST `/telemetry/v2/profile` - Create v2 profile
+- PUT `/telemetry/v2/profile` - Update v2 profile
+- DELETE `/telemetry/v2/profile/{id}` - Delete v2 profile
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-TEL-003-01 | Create v2 profile | 201 Created | ⚠️ Needs refactor |
+| TC-TEL-003-02 | Create duplicate v2 profile | 409 Conflict | 🔲 Not tested |
+| TC-TEL-003-03 | Get all v2 profiles | 200 OK + list | ⚠️ Needs refactor |
+| TC-TEL-003-04 | Get v2 profile by ID | 200 OK + entity | ⚠️ Needs refactor |
+| TC-TEL-003-05 | Update v2 profile | 200 OK | ⚠️ Needs refactor |
+| TC-TEL-003-06 | Delete v2 profile | 200 OK | ⚠️ Needs refactor |
+
+---
+
+### UC-TEL-004: Telemetry Two Rules Management (v2)
+
+**Description**: CRUD operations for Telemetry 2.0 rules.
+
+**API Endpoints**:
+- GET `/telemetry/v2/rule` - List all v2 rules
+- GET `/telemetry/v2/rule/{id}` - Get v2 rule by ID
+- POST `/telemetry/v2/rule` - Create v2 rule
+- PUT `/telemetry/v2/rule` - Update v2 rule
+- DELETE `/telemetry/v2/rule/{id}` - Delete v2 rule
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-TEL-004-01 | Create v2 rule | 201 Created | ⚠️ Needs refactor |
+| TC-TEL-004-02 | Create v2 rule invalid profile | 400 Bad Request | 🔲 Not tested |
+| TC-TEL-004-03 | Get all v2 rules | 200 OK + list | ⚠️ Needs refactor |
+| TC-TEL-004-04 | Get v2 rule by ID | 200 OK + entity | ⚠️ Needs refactor |
+| TC-TEL-004-05 | Update v2 rule | 200 OK | ⚠️ Needs refactor |
+| TC-TEL-004-06 | Delete v2 rule | 200 OK | ⚠️ Needs refactor |
+
+---
+
+### UC-TEL-005: Telemetry Log Uploader (v2)
+
+**Description**: Log uploader configuration management.
+
+**API Endpoints**:
+- GET `/telemetry/v2/logUploader` - Get log uploader config
+- POST `/telemetry/v2/logUploader` - Create/Update config
+
+**Test Scenarios**:
+
+| ID | Scenario | Expected | Current Status |
+|----|----------|----------|----------------|
+| TC-TEL-005-01 | Get log uploader config | 200 OK | ⚠️ Needs refactor |
+| TC-TEL-005-02 | Create log uploader config | 201 Created | ⚠️ Needs refactor |
+| TC-TEL-005-03 | Update log uploader config | 200 OK | ⚠️ Needs refactor |
+
+---
+
+## Current Issues
+
+### Issue TEL-001: TestMain Mock Timing
+
+**File**: `telemetry_profile_handler_test.go`
+
+**Current Code**:
+```go
+func TestMain(m *testing.M) {
+    // Config loaded
+    // Server created (connects to Cassandra!)
+    // Mock not initialized first
+}
+```
+
+**Solution**:
+```go
+func TestMain(m *testing.M) {
+    // Load config
+    
+    if IsMockDatabaseEnabled() {
+        InitMockDatabase()  // Initialize mock FIRST
+    }
+    
+    // Create server
+    server = oshttp.NewWebconfigServer(...)
+}
+```
+
+---
+
+### Issue TEL-002: Shared Test Data
+
+**Problem**: Tests share telemetry profiles/rules, causing test pollution.
+
+**Solution**: Each test creates unique entities with UUIDs.
+
+```go
+func TestCreateTelemetryProfile(t *testing.T) {
+    id := uuid.New().String()
+    profile := NewTestTelemetryProfile(id)
+    
+    cleanup := createTestEntity(t, profile, db.TABLE_TELEMETRY_TWO_PROFILES)
+    defer cleanup()
+    
+    // Test logic
+}
+```
+
+---
+
+## Test Data Fixtures
+
+```go
+// Telemetry Profile v1 fixture
+func NewTestTelemetryProfile(id string) *logupload.PermanentTelemetryProfile {
+    return &logupload.PermanentTelemetryProfile{
+        ID:              id,
+        Name:            "Test_Profile_" + id[:8],
+        ApplicationType: "stb",
+        TelemetryProfile: []logupload.TelemetryElement{
+            {
+                Header: "Test_Header",
+                Content: "Test_Content",
+                Type:    "Test_Type",
+            },
+        },
+    }
+}
+
+// Telemetry Rule v1 fixture
+func NewTestTelemetryRule(id, profileId string) *logupload.TelemetryRule {
+    return &logupload.TelemetryRule{
+        ID:              id,
+        Name:            "Test_Rule_" + id[:8],
+        BoundTelemetryId: profileId,
+        ApplicationType: "stb",
+    }
+}
+
+// Telemetry Two Profile v2 fixture
+func NewTestTelemetryTwoProfile(id string) *logupload.TelemetryTwoProfile {
+    return &logupload.TelemetryTwoProfile{
+        ID:              id,
+        Name:            "Test_V2_Profile_" + id[:8],
+        ApplicationType: "stb",
+    }
+}
+
+// Telemetry Two Rule v2 fixture
+func NewTestTelemetryTwoRule(id, profileId string) *logupload.TelemetryTwoRule {
+    return &logupload.TelemetryTwoRule{
+        ID:                id,
+        Name:              "Test_V2_Rule_" + id[:8],
+        BoundTelemetryIds: []string{profileId},
+        ApplicationType:   "stb",
+    }
+}
+```
+
+---
+
+## Dependencies
+
+### Internal Dependencies
+- `adminapi/change/` - Change management integration
+- `shared/logupload/` - Shared telemetry types
+- `shared/change/` - Change entity types
+
+### External Dependencies
+- `github.com/rdkcentral/xconfwebconfig/db`
+- `github.com/rdkcentral/xconfwebconfig/shared/logupload`
+- `github.com/rdkcentral/xconfwebconfig/shared/change`
+
+---
+
+## Coverage Goals
+
+| File | Current | Target | Focus Areas |
+|------|---------|--------|-------------|
+| telemetry_profile_handler.go | ~55% | 85% | Error paths |
+| telemetry_profile_service.go | ~60% | 85% | Business logic |
+| telemetry_rule_handler.go | ~50% | 85% | CRUD paths |
+| telemetry_two_profile_handler.go | ~55% | 85% | v2 CRUD |
+| telemetry_two_rule_handler.go | ~50% | 85% | v2 rules |
+| telemetry_two_loguploader_handler.go | ~45% | 80% | Config mgmt |
+
+---
+
+## Test Execution Commands
+
+```bash
+# Run all telemetry tests with mock
+USE_MOCK_DB=true go test -v ./adminapi/telemetry/... -count=1
+
+# Run specific test pattern
+USE_MOCK_DB=true go test -v ./adminapi/telemetry/... -run "TelemetryTwo" -count=1
+
+# Run with coverage
+USE_MOCK_DB=true go test ./adminapi/telemetry/... -coverprofile=telemetry.out
+go tool cover -func=telemetry.out | grep -E "handler|service"
+
+# Generate HTML report
+go tool cover -html=telemetry.out -o telemetry_coverage.html
+```

--- a/openspec/changes/unit-test-enhancement/specs/test-patterns.md
+++ b/openspec/changes/unit-test-enhancement/specs/test-patterns.md
@@ -1,0 +1,531 @@
+# Test Pattern Specification
+
+## Overview
+
+This specification defines the standardized patterns for unit tests in xconfadmin with mock/real DB support.
+
+## 1. Test File Structure Spec
+
+### 1.1 Package-Level Test Initialization
+
+Every package with DB-dependent tests **MUST** have:
+
+```go
+// File: <package>/test_utils.go
+
+package <package>
+
+import (
+    "testing"
+    "github.com/rdkcentral/xconfadmin/adminapi/dcm/mocks"
+    "github.com/rdkcentral/xconfwebconfig/db"
+    xwlogupload "github.com/rdkcentral/xconfwebconfig/shared/logupload"
+)
+
+// Package-level variables for mock state
+var (
+    mockDaoInstance               *mocks.MockCachedSimpleDao
+    useMockDatabase               = false
+    originalGetCachedSimpleDaoFunc func() db.CachedSimpleDao
+)
+
+// InitMockDatabase - Call in TestMain when USE_MOCK_DB=true
+func InitMockDatabase() *mocks.MockCachedSimpleDao {
+    mockDaoInstance = mocks.NewMockCachedSimpleDao()
+    useMockDatabase = true
+    
+    originalGetCachedSimpleDaoFunc = xwlogupload.GetCachedSimpleDaoFunc
+    xwlogupload.GetCachedSimpleDaoFunc = func() db.CachedSimpleDao {
+        return mockDaoInstance
+    }
+    
+    return mockDaoInstance
+}
+
+// DisableMockDatabase - Call in TestMain cleanup
+func DisableMockDatabase() {
+    if originalGetCachedSimpleDaoFunc != nil {
+        xwlogupload.GetCachedSimpleDaoFunc = originalGetCachedSimpleDaoFunc
+    }
+    useMockDatabase = false
+    mockDaoInstance = nil
+}
+
+// IsMockDatabaseEnabled - Check current mode
+func IsMockDatabaseEnabled() bool {
+    return useMockDatabase
+}
+
+// ClearMockDatabase - Clear all mock data between tests
+func ClearMockDatabase() {
+    if useMockDatabase && mockDaoInstance != nil {
+        mockDaoInstance.Clear()
+    }
+}
+
+// GetMockDaoForTesting - Get mock instance for assertions
+func GetMockDaoForTesting() *mocks.MockCachedSimpleDao {
+    return mockDaoInstance
+}
+
+// SkipIfMockDatabase - Skip integration tests in mock mode
+func SkipIfMockDatabase(t *testing.T) {
+    if useMockDatabase {
+        t.Skip("Skipping integration test in mock mode")
+    }
+}
+```
+
+### 1.2 TestMain Pattern
+
+Every package with DB tests **MUST** have one file with `TestMain`:
+
+```go
+// File: <package>/<main_test_file>_test.go
+
+func TestMain(m *testing.M) {
+    // 1. Check environment for mode selection
+    useMock := os.Getenv("USE_MOCK_DB")
+    isMockMode := useMock == "true" || useMock == "1" || useMock == ""
+    
+    if isMockMode {
+        fmt.Println("MODE: Mock Database (fast)")
+        
+        // 2. Initialize mock DB client FIRST (prevents distributed lock panics)
+        mockDbClient := mocks.NewMockDatabaseClient()
+        db.SetDatabaseClient(mockDbClient)
+        
+        // 3. Register required table configurations
+        db.RegisterTableConfigSimple(db.TABLE_XXX, xxx.NewXxxInf)
+        // ... register all tables used by this package
+        
+        // 4. Initialize mock DAO
+        InitMockDatabase()
+        defer DisableMockDatabase()
+    } else {
+        fmt.Println("MODE: Real Database (integration)")
+    }
+    
+    // 5. Common initialization (config, server, router)
+    // ... setup code that works for both modes
+    
+    // 6. Run all tests
+    code := m.Run()
+    
+    // 7. Cleanup
+    // ... teardown code
+    
+    os.Exit(code)
+}
+```
+
+## 2. Test Function Pattern Spec
+
+### 2.1 Basic Idempotent Test
+
+```go
+func TestEntityCreate(t *testing.T) {
+    // 1. Generate unique ID for this test run
+    testID := "test-" + uuid.New().String()
+    
+    // 2. Create test entity
+    entity := &Entity{
+        ID:   testID,
+        Name: "Test Entity",
+    }
+    
+    // 3. Cleanup ONLY this entity (surgical cleanup)
+    defer func() {
+        if IsMockDatabaseEnabled() {
+            GetMockDaoForTesting().DeleteOne(
+                db.GetDefaultTenantId(), 
+                db.TABLE_ENTITY, 
+                testID,
+            )
+        } else {
+            db.GetCachedSimpleDao().DeleteOne(
+                db.GetDefaultTenantId(), 
+                db.TABLE_ENTITY, 
+                testID,
+            )
+        }
+    }()
+    
+    // 4. Execute operation
+    err := CreateEntity(entity)
+    
+    // 5. Assert results
+    assert.NilError(t, err)
+    
+    // 6. Verify by reading back
+    retrieved := GetEntity(db.GetDefaultTenantId(), testID)
+    assert.Assert(t, retrieved != nil)
+    assert.Equal(t, entity.Name, retrieved.Name)
+}
+```
+
+### 2.2 Test with Multiple Entities
+
+```go
+func TestBatchOperation(t *testing.T) {
+    // Track all IDs for cleanup
+    var insertedIDs []string
+    
+    // Cleanup all inserted entities
+    defer func() {
+        for _, id := range insertedIDs {
+            deleteEntityById(id)
+        }
+    }()
+    
+    // Create multiple entities
+    for i := 0; i < 3; i++ {
+        id := fmt.Sprintf("batch-test-%d-%s", i, uuid.New().String())
+        entity := &Entity{ID: id, Name: fmt.Sprintf("Entity %d", i)}
+        
+        err := CreateEntity(entity)
+        assert.NilError(t, err)
+        
+        insertedIDs = append(insertedIDs, id)
+    }
+    
+    // Test batch operation
+    results := GetAllEntities()
+    assert.Assert(t, len(results) >= 3)
+}
+```
+
+### 2.3 Test Helper Pattern
+
+```go
+// Helper function that returns cleanup function
+func createTestEntityWithCleanup(t *testing.T, name string) (*Entity, func()) {
+    id := "helper-" + uuid.New().String()
+    entity := &Entity{ID: id, Name: name}
+    
+    err := CreateEntity(entity)
+    assert.NilError(t, err)
+    
+    cleanup := func() {
+        deleteEntityById(id)
+    }
+    
+    return entity, cleanup
+}
+
+// Usage in test
+func TestSomething(t *testing.T) {
+    entity, cleanup := createTestEntityWithCleanup(t, "Test")
+    defer cleanup()
+    
+    // Test logic using entity
+}
+```
+
+## 3. FORBIDDEN Patterns
+
+### 3.1 ❌ NEVER: Double Cleanup
+
+```go
+// WRONG - Double cleanup
+func TestBad(t *testing.T) {
+    DeleteAllEntities()        // ❌ REMOVE THIS
+    defer DeleteAllEntities()  // ❌ CHANGE TO SURGICAL
+    
+    // test code
+}
+```
+
+### 3.2 ❌ NEVER: Complete Table Wipe
+
+```go
+// WRONG - Wipes ALL data
+func TestBad(t *testing.T) {
+    defer func() {
+        for _, table := range db.GetAllTableInfo() {
+            cassandra.DeleteAllXconfData(table)  // ❌ FORBIDDEN
+        }
+    }()
+}
+```
+
+### 3.3 ❌ NEVER: Test Dependency
+
+```go
+// WRONG - Tests depend on each other
+func TestCreate(t *testing.T) {
+    CreateEntity(entity)  // Leaves in DB
+}
+
+func TestRead(t *testing.T) {
+    GetEntity(id)  // ❌ Assumes TestCreate ran first
+}
+```
+
+### 3.4 ❌ NEVER: Hard-coded IDs Without Cleanup
+
+```go
+// WRONG - Same ID on every run, no cleanup
+func TestBad(t *testing.T) {
+    entity := &Entity{ID: "fixed-id-123"}  // ❌ Collision risk
+    CreateEntity(entity)
+    // No cleanup!
+}
+```
+
+### 3.5 ❌ NEVER: Calling Other Test Functions
+
+```go
+// WRONG - Test calls another test
+func TestA(t *testing.T) {
+    TestB(t)  // ❌ FORBIDDEN
+}
+```
+
+## 4. Delete Helper Spec
+
+### 4.1 Surgical Delete Helper
+
+```go
+// deleteEntityById - works with both mock and real DB
+func deleteEntityById(id string) error {
+    if IsMockDatabaseEnabled() {
+        return GetMockDaoForTesting().DeleteOne(
+            db.GetDefaultTenantId(),
+            db.TABLE_ENTITY,
+            id,
+        )
+    }
+    return db.GetCachedSimpleDao().DeleteOne(
+        db.GetDefaultTenantId(),
+        db.TABLE_ENTITY,
+        id,
+    )
+}
+```
+
+### 4.2 Multi-Table Cleanup Helper
+
+```go
+// cleanupTestData - for tests that insert into multiple tables
+func cleanupTestData(entityID string, relatedIDs map[string][]string) {
+    // Delete main entity
+    deleteEntityById(entityID)
+    
+    // Delete related records
+    for tableName, ids := range relatedIDs {
+        for _, id := range ids {
+            deleteFromTable(tableName, id)
+        }
+    }
+}
+```
+
+## 5. Mock vs Real DB Behavior Spec
+
+### 5.1 Operations That Should Work Identically
+
+| Operation | Mock | Real | Notes |
+|-----------|------|------|-------|
+| GetOne | ✓ | ✓ | Returns nil if not found |
+| SetOne | ✓ | ✓ | Creates or updates |
+| DeleteOne | ✓ | ✓ | No error if not exists |
+| GetAllAsList | ✓ | ✓ | Empty list if none |
+| GetAllAsMap | ✓ | ✓ | Empty map if none |
+
+### 5.2 Operations That May Differ
+
+| Operation | Mock Behavior | Real Behavior | Handling |
+|-----------|--------------|---------------|----------|
+| Distributed Lock | No-op | Actually locks | Mock doesn't test lock contention |
+| Transaction | Not supported | Depends on schema | Skip transactional tests in mock |
+| Concurrent writes | In-memory sync | Cassandra consistency | Test with `-race` flag |
+
+### 5.3 Integration-Only Tests
+
+Tests that **MUST** use real DB:
+
+```go
+func TestDistributedLockBehavior(t *testing.T) {
+    SkipIfMockDatabase(t)  // Only run with real DB
+    
+    // Test actual lock behavior
+}
+
+func TestCassandraConsistency(t *testing.T) {
+    SkipIfMockDatabase(t)
+    
+    // Test consistency behavior
+}
+```
+
+## 6. Coverage Verification Spec
+
+### 6.1 Per-Function Verification
+
+After each test function modification:
+
+```bash
+# Mock mode
+USE_MOCK_DB=true go test -v -run TestFunctionName \
+    -coverprofile=func_mock.out \
+    ./path/to/package/...
+
+# Check specific function coverage
+go tool cover -func=func_mock.out | grep "function_under_test"
+
+# Real mode (if DB available)
+USE_MOCK_DB=false go test -v -run TestFunctionName \
+    -coverprofile=func_real.out \
+    ./path/to/package/...
+
+go tool cover -func=func_real.out | grep "function_under_test"
+```
+
+### 6.2 Required Coverage Documentation
+
+In tasks.md, after completing each task:
+
+```markdown
+**Coverage Results**:
+| Mode | Pass | Coverage | Function Lines |
+|------|------|----------|----------------|
+| Mock | ✅   | 85.2%    | 42/50 covered  |
+| Real | ✅   | 85.2%    | 42/50 covered  |
+```
+
+## 7. Naming Convention Spec
+
+### 7.1 Test Function Names
+
+```
+Test<Entity><Operation>[_<Scenario>]
+
+Examples:
+- TestDeviceSettingCreate
+- TestDeviceSettingCreate_EmptyName
+- TestDeviceSettingCreate_DuplicateId
+- TestDeviceSettingGetById
+- TestDeviceSettingGetById_NotFound
+- TestDeviceSettingUpdate
+- TestDeviceSettingDelete
+```
+
+### 7.2 Test ID Prefixes
+
+```
+<module>-<operation>-<uuid>
+
+Examples:
+- dcm-create-a1b2c3d4-...
+- queries-model-e5f6g7h8-...
+- telemetry-rule-i9j0k1l2-...
+```
+
+## 8. Table Registration Spec
+
+### 8.1 Required Table Registrations by Module
+
+**DCM Module**:
+```go
+db.RegisterTableConfigSimple(db.TABLE_DCM_RULE, logupload.NewDCMGenericRuleInf)
+db.RegisterTableConfigSimple(db.TABLE_LOG_FILE, logupload.NewLogFileInf)
+db.RegisterTableConfigSimple(db.TABLE_LOG_FILE_LIST, logupload.NewLogFileListInf)
+db.RegisterTableConfigSimple(db.TABLE_LOG_UPLOAD_SETTINGS, logupload.NewLogUploadSettingsInf)
+db.RegisterTableConfigSimple(db.TABLE_DEVICE_SETTINGS, logupload.NewDeviceSettingsInf)
+db.RegisterTableConfigSimple(db.TABLE_VOD_SETTINGS, logupload.NewVodSettingsInf)
+db.RegisterTableConfigSimple(db.TABLE_UPLOAD_REPOSITORY, logupload.NewUploadRepositoryInf)
+db.RegisterTableConfigSimple(db.TABLE_XCONF_CHANGE, db.NewChangedDataInf)
+```
+
+**Queries Module**:
+```go
+db.RegisterTableConfigSimple(db.TABLE_FIRMWARE_CONFIG, firmware.NewFirmwareConfigInf)
+db.RegisterTableConfigSimple(db.TABLE_FIRMWARE_RULE, firmware.NewFirmwareRuleInf)
+db.RegisterTableConfigSimple(db.TABLE_FIRMWARE_RULE_TEMPLATE, firmware.NewFirmwareRuleTemplateInf)
+db.RegisterTableConfigSimple(db.TABLE_IP_ADDRESS_GROUP, core.NewIpAddressGroupInf)
+db.RegisterTableConfigSimple(db.TABLE_MAC_LIST, core.NewGenericNamespacedListInf)
+db.RegisterTableConfigSimple(db.TABLE_MODELS, core.NewModelInf)
+db.RegisterTableConfigSimple(db.TABLE_ENVIRONMENTS, core.NewEnvironmentInf)
+// ... additional tables
+```
+
+**Telemetry Module**:
+```go
+db.RegisterTableConfigSimple(db.TABLE_TELEMETRY_RULES, logupload.NewTelemetryRuleInf)
+db.RegisterTableConfigSimple(db.TABLE_TELEMETRY_TWO_RULES, logupload.NewTelemetryTwoRuleInf)
+db.RegisterTableConfigSimple(db.TABLE_TELEMETRY_TWO_PROFILES, logupload.NewTelemetryTwoProfileInf)
+db.RegisterTableConfigSimple(db.TABLE_PERMANENT_TELEMETRY_PROFILE, logupload.NewPermanentTelemetryProfileInf)
+```
+
+## 9. Error Handling Spec
+
+### 9.1 Test Setup Errors
+
+```go
+func TestSomething(t *testing.T) {
+    entity, err := setupTestData()
+    if err != nil {
+        t.Fatalf("Setup failed: %v", err)  // Fatal stops test
+    }
+    defer cleanup()
+    
+    // Test code
+}
+```
+
+### 9.2 Cleanup Errors
+
+```go
+func TestSomething(t *testing.T) {
+    defer func() {
+        if err := cleanup(); err != nil {
+            t.Logf("Warning: cleanup failed: %v", err)  // Log but don't fail
+        }
+    }()
+    
+    // Test code
+}
+```
+
+## 10. Concurrency Spec
+
+### 10.1 Race Detection
+
+Always run tests with race detection:
+
+```bash
+USE_MOCK_DB=true go test -race ./...
+```
+
+### 10.2 Parallel Tests
+
+For truly independent tests:
+
+```go
+func TestA(t *testing.T) {
+    t.Parallel()  // Can run concurrently with other parallel tests
+    
+    // Each parallel test MUST use unique IDs
+    id := "parallel-a-" + uuid.New().String()
+    // ...
+}
+
+func TestB(t *testing.T) {
+    t.Parallel()
+    
+    id := "parallel-b-" + uuid.New().String()
+    // ...
+}
+```
+
+### 10.3 Non-Parallel Tests
+
+Tests sharing state should NOT be parallel:
+
+```go
+func TestSequentialA(t *testing.T) {
+    // No t.Parallel() - runs sequentially
+    // Can use shared test fixtures
+}
+```

--- a/openspec/changes/unit-test-enhancement/specs/use-cases.md
+++ b/openspec/changes/unit-test-enhancement/specs/use-cases.md
@@ -1,0 +1,442 @@
+# Use Cases Specification
+
+## Overview
+
+Complete catalog of all use cases for xconfadmin unit test enhancement, organized by module and functionality.
+
+---
+
+## Use Case Index
+
+```
+UC-DCM-001    Device Settings Management
+UC-DCM-002    VOD Settings Management
+UC-DCM-003    Log Upload Settings Management
+UC-DCM-004    Log Repository Settings Management
+UC-DCM-005    DCM Formula Management
+
+UC-QRY-001    Model Management
+UC-QRY-002    Environment Management
+UC-QRY-003    Firmware Configuration
+UC-QRY-004    Firmware Rules
+UC-QRY-005    Namespaced Lists
+UC-QRY-006    Filters Management
+UC-QRY-007    Percentage Beans
+UC-QRY-008    AMV Rules
+
+UC-TEL-001    Telemetry Profile Management (v1)
+UC-TEL-002    Telemetry Rules Management (v1)
+UC-TEL-003    Telemetry Two Profile Management (v2)
+UC-TEL-004    Telemetry Two Rules Management (v2)
+UC-TEL-005    Telemetry Log Uploader
+
+UC-CHG-001    Change Request Management
+UC-CHG-002    Change Approval Workflow
+UC-CHG-003    Telemetry Change Management
+
+UC-SET-001    Setting Profile Management
+UC-SET-002    Setting Rule Management
+
+UC-RFC-001    Feature Management
+UC-RFC-002    Feature Rule Management
+
+UC-TAG-001    Tag Management
+UC-TAG-002    Tag Member Management
+
+UC-MOCK-001   Mock Database Operations
+UC-MOCK-002   Real Database Operations
+UC-MOCK-003   Database Mode Switching
+```
+
+---
+
+## Detailed Use Cases
+
+### UC-DCM-001: Device Settings Management
+
+**ID**: UC-DCM-001  
+**Module**: adminapi/dcm/  
+**Priority**: High  
+**Complexity**: Medium
+
+#### Description
+CRUD operations for managing device settings that control how devices check in with the server.
+
+#### Actors
+- Admin User (primary)
+- System (automated processes)
+
+#### Preconditions
+1. User is authenticated with valid SAT token
+2. Application type cookie is set (stb/xhome/etc)
+3. User has write permissions for device settings
+
+#### Main Flow
+
+**Create Device Setting (UC-DCM-001-A)**
+1. User sends POST request to `/xconfAdminService/dcm/deviceSettings`
+2. System validates JSON payload
+3. System checks for duplicate ID
+4. System checks for duplicate name
+5. System stores entity in TABLE_DEVICE_SETTINGS
+6. System returns 201 Created with entity
+
+**Get All Device Settings (UC-DCM-001-B)**
+1. User sends GET request to `/xconfAdminService/dcm/deviceSettings`
+2. System retrieves all settings from cache
+3. System filters by application type
+4. System returns 200 OK with list
+
+**Get Device Setting by ID (UC-DCM-001-C)**
+1. User sends GET request to `/xconfAdminService/dcm/deviceSettings/{id}`
+2. System looks up entity by ID
+3. System returns 200 OK with entity
+
+**Update Device Setting (UC-DCM-001-D)**
+1. User sends PUT request to `/xconfAdminService/dcm/deviceSettings`
+2. System validates JSON payload
+3. System verifies entity exists
+4. System updates entity
+5. System returns 200 OK
+
+**Delete Device Setting (UC-DCM-001-E)**
+1. User sends DELETE request to `/xconfAdminService/dcm/deviceSettings/{id}`
+2. System verifies entity exists
+3. System checks for dependencies (DCM rules)
+4. System deletes entity
+5. System returns 200 OK
+
+#### Alternative Flows
+
+| ID | Condition | Response |
+|----|-----------|----------|
+| UC-DCM-001-A1 | Duplicate ID | 409 Conflict |
+| UC-DCM-001-A2 | Invalid JSON | 400 Bad Request |
+| UC-DCM-001-A3 | Missing required field | 400 Bad Request |
+| UC-DCM-001-C1 | Entity not found | 404 Not Found |
+| UC-DCM-001-D1 | Entity not found | 404 Not Found |
+| UC-DCM-001-E1 | Entity not found | 404 Not Found |
+| UC-DCM-001-E2 | Has dependencies | 409 Conflict |
+
+#### Test Cases
+
+| TC ID | Flow | Input | Expected Output | Mock | Real |
+|-------|------|-------|-----------------|------|------|
+| TC-001-01 | A | Valid device setting | 201 Created | ✅ | ✅ |
+| TC-001-02 | A1 | Duplicate ID | 409 Conflict | ✅ | ✅ |
+| TC-001-03 | A2 | Malformed JSON | 400 Bad Request | ✅ | ✅ |
+| TC-001-04 | B | No filters | 200 + list | ✅ | ✅ |
+| TC-001-05 | B | App type filter | 200 + filtered | ✅ | ✅ |
+| TC-001-06 | C | Valid ID | 200 + entity | ✅ | ✅ |
+| TC-001-07 | C1 | Invalid ID | 404 Not Found | ✅ | ✅ |
+| TC-001-08 | D | Valid update | 200 OK | ✅ | ✅ |
+| TC-001-09 | D1 | Non-existent ID | 404 Not Found | ✅ | ✅ |
+| TC-001-10 | E | Valid delete | 200 OK | ✅ | ✅ |
+| TC-001-11 | E1 | Non-existent ID | 404 Not Found | ✅ | ✅ |
+| TC-001-12 | E2 | Has DCM rule ref | 409 Conflict | ✅ | ✅ |
+
+---
+
+### UC-QRY-004: Firmware Rules
+
+**ID**: UC-QRY-004  
+**Module**: adminapi/queries/  
+**Priority**: High  
+**Complexity**: High
+
+#### Description
+CRUD operations for firmware rules that determine which firmware version a device should receive.
+
+#### Actors
+- Admin User
+- Firmware Release Manager
+
+#### Preconditions
+1. User is authenticated
+2. Referenced models exist
+3. Referenced firmware configs exist
+
+#### Main Flow
+
+**Create Firmware Rule (UC-QRY-004-A)**
+1. User sends POST request to `/xconfAdminService/queries/rules`
+2. System validates rule structure
+3. System validates referenced entities (model, environment, config)
+4. System checks rule condition validity
+5. System stores rule in TABLE_FIRMWARE_RULES
+6. System returns 201 Created
+
+**Get Firmware Rules (UC-QRY-004-B)**
+1. User sends GET request to `/xconfAdminService/queries/rules`
+2. System retrieves rules from cache
+3. System applies pagination if requested
+4. System returns 200 OK with rules
+
+**Apply Firmware Rule Template (UC-QRY-004-F)**
+1. User sends POST to `/xconfAdminService/queries/rules/template/apply`
+2. System loads template
+3. System substitutes parameters
+4. System creates rule from template
+5. System returns 201 Created
+
+#### Rule Validation Logic
+
+```go
+type FirmwareRuleValidation struct {
+    // Required fields
+    ID              string // Must be unique
+    Name            string // Must be unique per app type
+    Type            string // Must be valid rule type
+    ApplicationType string // Must be valid app type
+    
+    // Rule condition validation
+    Rule struct {
+        // Condition must reference valid entities
+        // Model ID must exist in TABLE_MODELS
+        // Environment ID must exist in TABLE_ENVIRONMENTS
+        // FirmwareConfig ID must exist in TABLE_FIRMWARE_CONFIGS
+    }
+}
+
+// Valid rule types
+var ValidRuleTypes = []string{
+    "MODEL_RULE",
+    "MAC_RULE", 
+    "IP_RULE",
+    "ENV_MODEL_RULE",
+    "TIME_FILTER",
+    "GLOBAL_PERCENT",
+}
+```
+
+#### Test Cases
+
+| TC ID | Flow | Input | Expected Output | Notes |
+|-------|------|-------|-----------------|-------|
+| TC-004-01 | A | Valid MODEL_RULE | 201 Created | Model must exist |
+| TC-004-02 | A | Valid MAC_RULE | 201 Created | MAC list must exist |
+| TC-004-03 | A | Valid IP_RULE | 201 Created | IP group must exist |
+| TC-004-04 | A | Invalid model ref | 400 Bad Request | Non-existent model |
+| TC-004-05 | A | Invalid rule type | 400 Bad Request | Unknown type |
+| TC-004-06 | B | No filters | 200 + list | Returns all rules |
+| TC-004-07 | B | By rule type | 200 + filtered | Filter works |
+| TC-004-08 | F | Valid template | 201 Created | Template applied |
+| TC-004-09 | F | Invalid template | 400 Bad Request | Missing params |
+
+---
+
+### UC-CHG-001: Change Request Management
+
+**ID**: UC-CHG-001  
+**Module**: adminapi/change/  
+**Priority**: High  
+**Complexity**: High
+
+#### Description
+Create and manage change requests for configuration modifications that require approval.
+
+#### Actors
+- Change Author (creates change)
+- Change Approver (approves/rejects)
+- System (tracks changes)
+
+#### Preconditions
+1. User is authenticated
+2. Entity being changed exists
+3. User has permission to create change requests
+
+#### Main Flow
+
+**Create Change Request (UC-CHG-001-A)**
+1. User modifies entity via normal API
+2. System detects change requires approval
+3. System creates Change record in TABLE_XCONF_CHANGE
+4. System stores old and new entity versions
+5. System returns change ID to user
+
+**Get Pending Changes (UC-CHG-001-B)**
+1. User sends GET to `/xconfAdminService/change/pending`
+2. System retrieves changes from TABLE_XCONF_CHANGE
+3. System returns list of pending changes
+
+**Approve Change (UC-CHG-001-C)**
+1. Approver sends POST to `/xconfAdminService/change/approve/{id}`
+2. System verifies change exists
+3. System applies change to production table
+4. System moves change to TABLE_XCONF_APPROVED_CHANGE
+5. System returns 200 OK
+
+**Reject Change (UC-CHG-001-D)**
+1. Approver sends POST to `/xconfAdminService/change/reject/{id}`
+2. System verifies change exists
+3. System deletes change from TABLE_XCONF_CHANGE
+4. System returns 200 OK
+
+#### Change Entity Structure
+
+```go
+type Change struct {
+    ID           string      `json:"id"`           // UUID
+    EntityId     string      `json:"entityId"`     // ID of changed entity
+    EntityType   string      `json:"entityType"`   // Type (e.g., "FirmwareRule")
+    Operation    string      `json:"operation"`    // CREATE/UPDATE/DELETE
+    OldEntity    interface{} `json:"oldEntity"`    // Previous state (null for CREATE)
+    NewEntity    interface{} `json:"newEntity"`    // New state (null for DELETE)
+    Author       string      `json:"author"`       // Who made the change
+    ApprovedUser string      `json:"approvedUser"` // Who approved (if approved)
+    Updated      int64       `json:"updated"`      // Timestamp
+}
+```
+
+#### Test Cases
+
+| TC ID | Flow | Input | Expected Output | Notes |
+|-------|------|-------|-----------------|-------|
+| TC-CHG-01 | A | Valid CREATE change | Change created | New entity |
+| TC-CHG-02 | A | Valid UPDATE change | Change created | Old + new entity |
+| TC-CHG-03 | A | Valid DELETE change | Change created | Old entity only |
+| TC-CHG-04 | B | No pending | 200 + empty | No changes |
+| TC-CHG-05 | B | Has pending | 200 + list | Returns changes |
+| TC-CHG-06 | C | Valid approve | 200 OK | Entity updated |
+| TC-CHG-07 | C | Non-existent | 404 Not Found | Invalid ID |
+| TC-CHG-08 | D | Valid reject | 200 OK | Change deleted |
+
+---
+
+### UC-MOCK-001: Mock Database Operations
+
+**ID**: UC-MOCK-001  
+**Module**: adminapi/dcm/mocks/  
+**Priority**: Critical  
+**Complexity**: Medium
+
+#### Description
+Verify mock database implementation correctly simulates real database behavior.
+
+#### Actors
+- Test Framework (automated)
+- Developer (runs tests)
+
+#### Preconditions
+1. USE_MOCK_DB=true environment variable set
+2. Mock DAO initialized before tests
+
+#### Main Flow
+
+**Mock GetOne (UC-MOCK-001-A)**
+1. Test creates entity via MockCachedSimpleDao.SetOne()
+2. Test retrieves entity via MockCachedSimpleDao.GetOne()
+3. Mock returns stored entity
+4. Test verifies entity matches
+
+**Mock SetOne (UC-MOCK-001-B)**
+1. Test calls MockCachedSimpleDao.SetOne() with entity
+2. Mock stores entity in memory map
+3. Test verifies no error returned
+4. Test verifies entity retrievable
+
+**Mock DeleteOne (UC-MOCK-001-C)**
+1. Test creates entity via SetOne()
+2. Test deletes entity via DeleteOne()
+3. Mock removes from memory map
+4. Test verifies GetOne returns "not found"
+
+**Mock GetAllAsList (UC-MOCK-001-D)**
+1. Test creates multiple entities via SetOne()
+2. Test calls GetAllAsList()
+3. Mock returns all entities in table
+4. Test verifies count and contents
+
+#### Test Cases
+
+| TC ID | Operation | Input | Expected Output | Notes |
+|-------|-----------|-------|-----------------|-------|
+| TC-MOCK-01 | SetOne | Valid entity | nil error | Stored |
+| TC-MOCK-02 | GetOne | Existing key | Entity, nil | Found |
+| TC-MOCK-03 | GetOne | Missing key | nil, error | Not found |
+| TC-MOCK-04 | DeleteOne | Existing key | nil error | Deleted |
+| TC-MOCK-05 | DeleteOne | Missing key | nil error | Idempotent |
+| TC-MOCK-06 | GetAllAsList | 5 entities | List of 5 | All returned |
+| TC-MOCK-07 | GetAllAsList | Empty table | Empty list | No error |
+| TC-MOCK-08 | GetAllAsMap | 3 entities | Map of 3 | All mapped |
+| TC-MOCK-09 | RefreshAll | Any table | nil error | No-op in mock |
+
+---
+
+### UC-MOCK-003: Database Mode Switching
+
+**ID**: UC-MOCK-003  
+**Module**: All modules  
+**Priority**: Critical  
+**Complexity**: Low
+
+#### Description
+Verify tests can switch between mock and real database modes seamlessly.
+
+#### Actors
+- CI/CD Pipeline
+- Developer
+
+#### Main Flow
+
+**Run with Mock (UC-MOCK-003-A)**
+1. Set USE_MOCK_DB=true
+2. Run tests
+3. Tests use MockCachedSimpleDao
+4. Tests complete in <30 seconds
+
+**Run with Real DB (UC-MOCK-003-B)**
+1. Set USE_MOCK_DB=false
+2. Ensure Cassandra is running
+3. Run tests
+4. Tests use real CachedSimpleDao
+5. Tests complete (may take minutes)
+
+**Skip Integration Tests in Mock Mode (UC-MOCK-003-C)**
+1. Test calls SkipIfMockDatabase(t)
+2. If USE_MOCK_DB=true, test skipped
+3. If USE_MOCK_DB=false, test runs
+
+#### Test Cases
+
+| TC ID | Mode | Test Type | Expected |
+|-------|------|-----------|----------|
+| TC-MODE-01 | Mock | Unit test | Runs |
+| TC-MODE-02 | Mock | Integration | Skipped |
+| TC-MODE-03 | Real | Unit test | Runs |
+| TC-MODE-04 | Real | Integration | Runs |
+| TC-MODE-05 | Mock | Full suite | <1 min |
+| TC-MODE-06 | Real | Full suite | <15 min |
+
+---
+
+## Use Case Dependencies
+
+```
+UC-MOCK-001 ─────────────────────────────────────┐
+                                                  │
+UC-DCM-001 ──► UC-DCM-005 (DCM rules reference   ├─► All Module Tests
+              device settings)                    │
+                                                  │
+UC-QRY-001 ──► UC-QRY-004 (Firmware rules        │
+              reference models)                   │
+                                                  │
+UC-QRY-004 ──► UC-CHG-001 (Changes reference     │
+              firmware rules)                    ─┘
+```
+
+---
+
+## Test Coverage Matrix
+
+| Use Case | Unit Tests | Integration | Mock Support | Real DB Support |
+|----------|------------|-------------|--------------|-----------------|
+| UC-DCM-001 | ⚠️ Partial | ⚠️ Monolithic | ✅ | ✅ |
+| UC-DCM-002 | ✅ Good | ⚠️ Monolithic | ✅ | ✅ |
+| UC-DCM-003 | ⚠️ Partial | ⚠️ Monolithic | ✅ | ✅ |
+| UC-DCM-004 | ⚠️ Partial | ⚠️ Monolithic | ✅ | ✅ |
+| UC-QRY-001 | ⚠️ Partial | ⚠️ Shared | ✅ | ✅ |
+| UC-QRY-004 | ⚠️ Partial | ⚠️ Shared | ✅ | ✅ |
+| UC-TEL-001 | ⚠️ Partial | ⚠️ Shared | ✅ | ✅ |
+| UC-CHG-001 | ⚠️ Partial | ❌ Missing | 🔲 | ✅ |
+| UC-MOCK-001 | ✅ Good | N/A | ✅ | N/A |

--- a/openspec/changes/unit-test-enhancement/status.md
+++ b/openspec/changes/unit-test-enhancement/status.md
@@ -1,0 +1,148 @@
+# Unit Test Enhancement - Status Tracker
+
+**Change ID**: unit-test-enhancement  
+**Created**: May 12, 2026  
+**Last Updated**: May 12, 2026
+
+---
+
+## Overall Progress
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│                    CHANGE LIFECYCLE                                 │
+├────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│  [✅] Exploration ──▶ [🔲] Implementation ──▶ [🔲] Validation       │
+│                                                                     │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+| Phase | Status | Progress |
+|-------|--------|----------|
+| Exploration | ✅ Complete | 100% |
+| Proposal | ✅ Created | 100% |
+| Design | ✅ Created | 100% |
+| Task Definition | ✅ Complete | 56 tasks |
+| Implementation | 🔲 Not Started | 0% |
+| Validation | 🔲 Not Started | 0% |
+
+---
+
+## Task Progress by Phase
+
+| Phase | Module | Total | Done | In Progress | Not Started |
+|-------|--------|-------|------|-------------|-------------|
+| 1 | Infrastructure | 1 | 0 | 0 | 1 |
+| 2 | DCM | 7 | 0 | 0 | 7 |
+| 3 | Queries | 13 | 0 | 0 | 13 |
+| 4 | Telemetry | 4 | 0 | 0 | 4 |
+| 5 | Change | 3 | 0 | 0 | 3 |
+| 6 | Setting | 2 | 0 | 0 | 2 |
+| 7 | Canary | 2 | 0 | 0 | 2 |
+| 8 | RFC | 2 | 0 | 0 | 2 |
+| 9 | Auth | 1 | 0 | 0 | 1 |
+| 10 | XCRP | 2 | 0 | 0 | 2 |
+| 11 | Firmware | 1 | 0 | 0 | 1 |
+| 12 | IP-MacRule | 1 | 0 | 0 | 1 |
+| 13 | Tagging API | 4 | 0 | 0 | 4 |
+| 14 | Shared | 6 | 0 | 0 | 6 |
+| 15 | HTTP | 1 | 0 | 0 | 1 |
+| 16 | Validation | 3 | 0 | 0 | 3 |
+| 17 | Common | 1 | 0 | 0 | 1 |
+| 18 | Additional DAO | 2 | 0 | 0 | 2 |
+| **TOTAL** | | **56** | **0** | **0** | **56** |
+
+---
+
+## Priority Breakdown
+
+| Priority | Total | Done | Remaining |
+|----------|-------|------|-----------|
+| P0 - Critical | 18 | 0 | 18 |
+| P1 - High | 35 | 0 | 35 |
+| P2 - Medium | 4 | 0 | 4 |
+
+---
+
+## Current Focus
+
+**Next Task**: Task 1.1 - Standardize Mock DAO Package  
+**Phase**: Phase 1 - Infrastructure Setup  
+**Priority**: P0 - Critical
+
+---
+
+## Artifacts Created
+
+| File | Status | Lines | Description |
+|------|--------|-------|-------------|
+| `proposal.md` | ✅ Created | 334 | Problem statement, goals, scope |
+| `design.md` | ✅ Created | 502 | Technical architecture |
+| `tasks.md` | ✅ Created | 1200+ | 56 tasks across 18 phases |
+| `status.md` | ✅ Created | -- | This file - progress tracking |
+
+### Specification Documents
+
+| Spec File | Status | Description |
+|-----------|--------|-------------|
+| `specs/test-patterns.md` | ✅ Created | Code patterns & anti-patterns |
+| `specs/module-inventory.md` | ✅ Created | Complete file inventory |
+| `specs/dcm-module-spec.md` | ✅ Created | DCM module detailed spec |
+| `specs/queries-module-spec.md` | ✅ Created | Queries module detailed spec |
+| `specs/telemetry-module-spec.md` | ✅ Created | Telemetry module detailed spec |
+| `specs/change-module-spec.md` | ✅ Created | Change module detailed spec |
+| `specs/shared-modules-spec.md` | ✅ Created | Shared modules detailed spec |
+| `specs/supporting-modules-spec.md` | ✅ Created | Setting, RFC, Canary, etc. |
+| `specs/mock-infrastructure-spec.md` | ✅ Created | Mock DAO implementation spec |
+| `specs/database-tables-spec.md` | ✅ Created | Complete table mapping |
+| `specs/use-cases.md` | ✅ Created | All use cases documented |
+
+---
+
+## Test Coverage Targets
+
+| Mode | Current | Target |
+|------|---------|--------|
+| Mock (USE_MOCK_DB=true) | -- | All tests pass |
+| Real (USE_MOCK_DB=false) | -- | All tests pass |
+
+---
+
+## Milestones
+
+- [ ] **M1**: Phase 1 Infrastructure complete (Task 1.1)
+- [ ] **M2**: All P0 Critical tasks complete (18 tasks)
+- [ ] **M3**: DCM module fully idempotent (Phase 2)
+- [ ] **M4**: Queries module fully idempotent (Phase 3)
+- [ ] **M5**: All modules have test_utils.go
+- [ ] **M6**: Full suite passes with USE_MOCK_DB=true
+- [ ] **M7**: Full suite passes with USE_MOCK_DB=false
+- [ ] **M8**: Coverage reports generated
+
+---
+
+## Commands
+
+```bash
+# Start implementation
+# Work through tasks.md sequentially, starting with Task 1.1
+
+# Verify mock mode after changes
+USE_MOCK_DB=true go test ./... -cover -count=1 -timeout=5m
+
+# Verify real mode after changes  
+USE_MOCK_DB=false go test ./... -cover -count=1 -timeout=45m
+
+# Generate coverage report
+USE_MOCK_DB=true go test ./... -coverprofile=coverage.out
+go tool cover -html=coverage.out -o coverage.html
+```
+
+---
+
+## Notes
+
+- Sample folder (`sample/xconfadmin/`) used for reference only - will be removed
+- No production code changes allowed - test files only
+- Each task must update coverage table after completion

--- a/openspec/changes/unit-test-enhancement/tasks.md
+++ b/openspec/changes/unit-test-enhancement/tasks.md
@@ -1,0 +1,1269 @@
+# Unit Test Enhancement - Tasks
+
+## Overview
+
+This document tracks all tasks for implementing dual-mode (mock/real DB) testing across xconfadmin modules.
+
+**Verification Loop**: After each task, run:
+```bash
+# Mock mode
+USE_MOCK_DB=true go test -run <TestFunctionName> -cover -coverprofile=mock.out ./path/to/package
+go tool cover -func=mock.out | grep <FunctionUnderTest>
+
+# Real mode (if DB available)
+USE_MOCK_DB=false go test -run <TestFunctionName> -cover -coverprofile=real.out ./path/to/package
+go tool cover -func=real.out | grep <FunctionUnderTest>
+```
+
+---
+
+## Phase 1: Infrastructure Setup
+
+### Task 1.1: Standardize Mock DAO Package
+**Status**: 🔲 Not Started  
+**Priority**: P0 - Critical  
+**Module**: `adminapi/dcm/mocks/`
+
+**Description**: Ensure mock DAO package is complete and reusable by all modules.
+
+**Subtasks**:
+- [ ] Verify `mock_dao.go` implements all `CachedSimpleDao` methods
+- [ ] Verify `mock_database_client.go` implements `DatabaseClient` interface
+- [ ] Add missing methods if any
+- [ ] Add unit tests for mock implementations
+
+**Files**:
+- `adminapi/dcm/mocks/mock_dao.go`
+- `adminapi/dcm/mocks/mock_dao_test.go`
+- `adminapi/dcm/mocks/mock_database_client.go`
+- `adminapi/dcm/mocks/mock_database_client_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+## Phase 2: DCM Module Enhancement
+
+### Task 2.1: Fix DCM TestMain Mock Initialization
+**Status**: 🔲 Not Started  
+**Priority**: P0 - Critical  
+**Module**: `adminapi/dcm/`
+
+**Description**: Fix TestMain to properly initialize mock DB before server creation.
+
+**Current Issue**:
+```go
+// Current: Initializes mock AFTER server tries to connect to Cassandra
+// This causes panic when USE_MOCK_DB=true
+```
+
+**Subtasks**:
+- [ ] Move mock initialization before `NewWebconfigServer()`
+- [ ] Ensure mock DB client is set before any DB operations
+- [ ] Test with `USE_MOCK_DB=true`
+- [ ] Test with `USE_MOCK_DB=false`
+
+**Files**:
+- `adminapi/dcm/dcmformula_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 2.2: DCM Device Settings - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/dcm/`
+
+**Description**: Split `TestAllDeviceSettingsApis` into independent tests.
+
+**Current Issue**:
+```go
+func TestAllDeviceSettingsApis(t *testing.T) {
+    // One giant test doing CRUD - not idempotent
+}
+```
+
+**Subtasks**:
+- [ ] Create `TestCreateDeviceSetting`
+- [ ] Create `TestGetDeviceSettingById`
+- [ ] Create `TestGetAllDeviceSettings`
+- [ ] Create `TestUpdateDeviceSetting`
+- [ ] Create `TestDeleteDeviceSetting`
+- [ ] Each test sets up own data and cleans up only its data
+- [ ] Remove original `TestAllDeviceSettingsApis`
+
+**Files**:
+- `adminapi/dcm/device_settings_e2e_test.go`
+- `adminapi/dcm/device_settings_handler_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 2.3: DCM Vod Settings - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/dcm/`
+
+**Subtasks**:
+- [ ] Split e2e test into independent functions
+- [ ] Add surgical cleanup for each test
+- [ ] Verify mock mode support
+
+**Files**:
+- `adminapi/dcm/vod_settings_e2e_test.go`
+- `adminapi/dcm/vod_settings_handler_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 2.4: DCM LogRepo Settings - Fix Double Cleanup
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/dcm/`
+
+**Description**: Fix double cleanup pattern in logrepo tests.
+
+**Current Issue**:
+```go
+DeleteAllEntities()      // ← Remove this
+defer DeleteAllEntities() // ← Keep only defer with surgical cleanup
+```
+
+**Subtasks**:
+- [ ] Remove initial `DeleteAllEntities()` calls
+- [ ] Replace `defer DeleteAllEntities()` with surgical cleanup
+- [ ] Track inserted IDs and delete only those
+
+**Files**:
+- `adminapi/dcm/logrepo_settings_service_test.go`
+- `adminapi/dcm/logrepo_settings_e2e_test.go`
+- `adminapi/dcm/logrepo_settings_handler_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 2.5: DCM LogUpload Settings - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/dcm/`
+
+**Subtasks**:
+- [ ] Split e2e test into independent functions
+- [ ] Add surgical cleanup
+- [ ] Verify mock mode
+
+**Files**:
+- `adminapi/dcm/logupload_settings_e2e_test.go`
+- `adminapi/dcm/logupload_settings_handler_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 2.6: DCM Formula Test - Fix Cleanup
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/dcm/`
+
+**Subtasks**:
+- [ ] Review all `DeleteAllEntities()` calls
+- [ ] Replace with surgical cleanup
+- [ ] Ensure idempotent tests
+
+**Files**:
+- `adminapi/dcm/dcmformula_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 2.7: DCM Test Page Controller - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P2 - Medium  
+**Module**: `adminapi/dcm/`
+
+**Files**:
+- `adminapi/dcm/test_page_controller_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+## Phase 3: Queries Module Enhancement
+
+### Task 3.1: Queries TestMain - Add Mock Support
+**Status**: 🔲 Not Started  
+**Priority**: P0 - Critical  
+**Module**: `adminapi/queries/`
+
+**Subtasks**:
+- [ ] Update TestMain with `USE_MOCK_DB` check
+- [ ] Initialize mock before server creation
+- [ ] Register all required table configs
+
+**Files**:
+- `adminapi/queries/queries_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 3.2: Queries Model Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/queries/`
+
+**Subtasks**:
+- [ ] Fix `model_handler_test.go`
+- [ ] Fix `model_service_test.go`
+- [ ] Fix `model_test.go`
+- [ ] Fix `model_query_update_delete_test.go`
+- [ ] Add surgical cleanup
+
+**Files**:
+- `adminapi/queries/model_handler_test.go`
+- `adminapi/queries/model_service_test.go`
+- `adminapi/queries/model_test.go`
+- `adminapi/queries/model_query_update_delete_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 3.3: Queries Firmware Config Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/queries/`
+
+**Files**:
+- `adminapi/queries/firmware_config_handler_test.go`
+- `adminapi/queries/firmware_config_service_test.go`
+- `adminapi/queries/firmware_config_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 3.4: Queries Firmware Rule Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/queries/`
+
+**Files**:
+- `adminapi/queries/firmware_rule_handler_test.go`
+- `adminapi/queries/firmware_rule_service_test.go`
+- `adminapi/queries/firmware_rule_test.go`
+- `adminapi/queries/firmware_rule_template_handler_test.go`
+- `adminapi/queries/firmware_rule_template_handler_additional_test.go`
+- `adminapi/queries/firmware_rule_template_service_test.go`
+- `adminapi/queries/firmware_rule_report_page_handler_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 3.5: Queries Feature Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/queries/`
+
+**Files**:
+- `adminapi/queries/feature_handler.go` (for reference)
+- `adminapi/queries/feature_entity_handler_test.go`
+- `adminapi/queries/feature_entity_service_test.go`
+- `adminapi/queries/feature_rule_handler_test.go`
+- `adminapi/queries/feature_rule_service_test.go`
+- `adminapi/queries/feature_service_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 3.6: Queries IP Address/MAC List Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/queries/`
+
+**Files**:
+- `adminapi/queries/ip_address_group_service_test.go`
+- `adminapi/queries/ipaddressgroup_maclist_handlers_test.go`
+- `adminapi/queries/mac_rule_bean_handler_test.go`
+- `adminapi/queries/maclist_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 3.7: Queries Filter Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/queries/`
+
+**Files**:
+- `adminapi/queries/ips_filter_service_test.go`
+- `adminapi/queries/location_filter_service_test.go`
+- `adminapi/queries/percent_filter_service_test.go`
+- `adminapi/queries/percentfilter_handler_test.go`
+- `adminapi/queries/ri_filter_service_test.go`
+- `adminapi/queries/time_filter_service_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 3.8: Queries Namespaced List Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/queries/`
+
+**Files**:
+- `adminapi/queries/namespaced_list_handler_test.go`
+- `adminapi/queries/namespaced_list_service_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 3.9: Queries Environment Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/queries/`
+
+**Files**:
+- `adminapi/queries/environment_handler_test.go`
+- `adminapi/queries/environment_service_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 3.10: Queries Percentage Bean Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/queries/`
+
+**Files**:
+- `adminapi/queries/percentage_bean_service_test.go`
+- `adminapi/queries/percentagebean_handler_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 3.11: Queries AMV Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/queries/`
+
+**Files**:
+- `adminapi/queries/amv_handler_test.go`
+- `adminapi/queries/amv_service_test.go`
+- `adminapi/queries/amv_test.go`
+- `adminapi/queries/activation_minimum_version_handler_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 3.12: Queries Log/Base/Common Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P2 - Medium  
+**Module**: `adminapi/queries/`
+
+**Files**:
+- `adminapi/queries/log_controller_test.go`
+- `adminapi/queries/log_file_handler_test.go`
+- `adminapi/queries/base_queries_controller_test.go`
+- `adminapi/queries/baserule_validator_test.go`
+- `adminapi/queries/common_test.go`
+- `adminapi/queries/converter_test.go`
+- `adminapi/queries/queries_handler_test.go`
+- `adminapi/queries/queries_helper_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 3.13: Queries Additional/Coverage Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P2 - Medium  
+**Module**: `adminapi/queries/`
+
+**Files**:
+- `adminapi/queries/additional_handler_test.go`
+- `adminapi/queries/additional_service_test.go`
+- `adminapi/queries/coverage_improvement_test.go`
+- `adminapi/queries/simple_service_test.go`
+- `adminapi/queries/firmware_simple_test.go`
+- `adminapi/queries/firmwares_test.go`
+- `adminapi/queries/firstreport_test.go`
+- `adminapi/queries/prioritizable_test.go`
+- `adminapi/queries/penetration_metrics_client_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+## Phase 4: Telemetry Module Enhancement
+
+### Task 4.1: Telemetry TestMain - Fix Mock Support
+**Status**: 🔲 Not Started  
+**Priority**: P0 - Critical  
+**Module**: `adminapi/telemetry/`
+
+**Subtasks**:
+- [ ] Update TestMain in `telemetry_profile_handler_test.go`
+- [ ] Initialize mock before server creation
+- [ ] Verify all tests pass with mock
+
+**Files**:
+- `adminapi/telemetry/telemetry_profile_handler_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 4.2: Telemetry Profile Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/telemetry/`
+
+**Files**:
+- `adminapi/telemetry/telemetry_profile_controller_test.go`
+- `adminapi/telemetry/telemetry_profile_handler_test.go`
+- `adminapi/telemetry/telemetry_profile_service_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 4.3: Telemetry Rule Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/telemetry/`
+
+**Files**:
+- `adminapi/telemetry/telemetry_rule_handler_test.go`
+- `adminapi/telemetry/telemetry_v2_rule_service_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 4.4: Telemetry Two Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/telemetry/`
+
+**Files**:
+- `adminapi/telemetry/telemetry_two_dao_test.go`
+- `adminapi/telemetry/telemetry_two_loguploader_handler_test.go`
+- `adminapi/telemetry/telemetry_two_profile_handler_test.go`
+- `adminapi/telemetry/telemetry_two_rule_hanlder_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+## Phase 5: Change Module Enhancement
+
+### Task 5.1: Change Module - Add test_utils.go
+**Status**: 🔲 Not Started  
+**Priority**: P0 - Critical  
+**Module**: `adminapi/change/`
+
+**Subtasks**:
+- [ ] Create `test_utils.go` with mock/real switching
+- [ ] Update TestMain in `change_handler_test.go`
+- [ ] Verify tests pass with mock
+
+**Files**:
+- `adminapi/change/test_utils.go` (NEW)
+- `adminapi/change/change_handler_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 5.2: Change Handler/Service Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/change/`
+
+**Files**:
+- `adminapi/change/change_handler_test.go`
+- `adminapi/change/change_service_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 5.3: Change Telemetry Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/change/`
+
+**Files**:
+- `adminapi/change/telemetry_profile_handler_test.go`
+- `adminapi/change/telemetry_two_change_handler_test.go`
+- `adminapi/change/telemetry_two_change_service_test.go`
+- `adminapi/change/telemetry_two_profile_handler_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+## Phase 6: Setting Module Enhancement
+
+### Task 6.1: Setting Module - Add test_utils.go and TestMain
+**Status**: 🔲 Not Started  
+**Priority**: P0 - Critical  
+**Module**: `adminapi/setting/`
+
+**Subtasks**:
+- [ ] Create `test_utils.go`
+- [ ] Add TestMain to one test file
+- [ ] Verify mock mode works
+
+**Files**:
+- `adminapi/setting/test_utils.go` (NEW)
+- `adminapi/setting/setting_profile_controller_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 6.2: Setting Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/setting/`
+
+**Files**:
+- `adminapi/setting/setting_profile_controller_test.go`
+- `adminapi/setting/setting_profile_service_test.go`
+- `adminapi/setting/setting_rule_controller_test.go`
+- `adminapi/setting/setting_rule_service_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+## Phase 7: Canary Module Enhancement
+
+### Task 7.1: Canary Module - Add test_utils.go and TestMain
+**Status**: 🔲 Not Started  
+**Priority**: P0 - Critical  
+**Module**: `adminapi/canary/`
+
+**Files**:
+- `adminapi/canary/test_utils.go` (NEW)
+- `adminapi/canary/canary_settings_handler_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 7.2: Canary Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/canary/`
+
+**Files**:
+- `adminapi/canary/canary_settings_handler_test.go`
+- `adminapi/canary/canary_settings_service_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+## Phase 8: RFC Module Enhancement
+
+### Task 8.1: RFC Feature Module - Add test_utils.go
+**Status**: 🔲 Not Started  
+**Priority**: P0 - Critical  
+**Module**: `adminapi/rfc/feature/`
+
+**Files**:
+- `adminapi/rfc/feature/test_utils.go` (NEW)
+- `adminapi/rfc/feature/feature_handler_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 8.2: RFC Feature Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/rfc/feature/`
+
+**Files**:
+- `adminapi/rfc/feature/feature_handler_test.go`
+- `adminapi/rfc/feature/feature_control_settings_test.go`
+- `adminapi/rfc/feature/feature_test_helpers_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+## Phase 9: Auth Module Enhancement
+
+### Task 9.1: Auth Module - Add test_utils.go and Fix TestMain
+**Status**: 🔲 Not Started  
+**Priority**: P0 - Critical  
+**Module**: `adminapi/auth/`
+
+**Description**: Auth tests panic without DB. Need mock support.
+
+**Files**:
+- `adminapi/auth/test_utils.go` (NEW)
+- `adminapi/auth/idp_service_handler_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+## Phase 10: XCRP Module Enhancement
+
+### Task 10.1: XCRP Module - Add test_utils.go and TestMain
+**Status**: 🔲 Not Started  
+**Priority**: P0 - Critical  
+**Module**: `adminapi/xcrp/`
+
+**Files**:
+- `adminapi/xcrp/test_utils.go` (NEW)
+- `adminapi/xcrp/recooking_lockdown_settings_handler_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 10.2: XCRP Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/xcrp/`
+
+**Files**:
+- `adminapi/xcrp/recooking_lockdown_settings_handler_test.go`
+- `adminapi/xcrp/recooking_status_handler_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+## Phase 11: Firmware Module Enhancement
+
+### Task 11.1: Firmware Module - Add test_utils.go and TestMain
+**Status**: 🔲 Not Started  
+**Priority**: P0 - Critical  
+**Module**: `adminapi/firmware/`
+
+**Files**:
+- `adminapi/firmware/test_utils.go` (NEW)
+- `adminapi/firmware/firmware_test_page_controller_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+## Phase 12: Configuration IP-MacRule Module Enhancement
+
+### Task 12.1: IP-MacRule Module - Add test_utils.go and TestMain
+**Status**: 🔲 Not Started  
+**Priority**: P0 - Critical  
+**Module**: `adminapi/configuration/ip-macrule/`
+
+**Files**:
+- `adminapi/configuration/ip-macrule/test_utils.go` (NEW)
+- `adminapi/configuration/ip-macrule/ip_mac_ruleconfig_handler_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+## Phase 13: Tagging API Module Enhancement
+
+### Task 13.1: Tagging Tag Module - Add test_utils.go and TestMain
+**Status**: 🔲 Not Started  
+**Priority**: P0 - Critical  
+**Module**: `taggingapi/tag/`
+
+**Files**:
+- `taggingapi/tag/test_utils.go` (NEW)
+- `taggingapi/tag/tag_handler_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 13.2: Tag Tests - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `taggingapi/tag/`
+
+**Files**:
+- `taggingapi/tag/tag_handler_test.go`
+- `taggingapi/tag/tag_member_service_test.go`
+- `taggingapi/tag/tag_normalization_service_test.go`
+- `taggingapi/tag/tag_service_test.go`
+- `taggingapi/tag/tag_member_benchmark_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 13.3: Tagging Config Module - Add test_utils.go
+**Status**: 🔲 Not Started  
+**Priority**: P0 - Critical  
+**Module**: `taggingapi/config/`
+
+**Files**:
+- `taggingapi/config/test_utils.go` (NEW)
+- `taggingapi/config/tag_config_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 13.4: Tagging Percentage Module - Add test_utils.go
+**Status**: 🔲 Not Started  
+**Priority**: P0 - Critical  
+**Module**: `taggingapi/percentage/`
+
+**Files**:
+- `taggingapi/percentage/test_utils.go` (NEW)
+- `taggingapi/percentage/percentage_service_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+## Phase 14: Shared Module Enhancement
+
+### Task 14.1: Shared estbfirmware - Add test_utils.go
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `shared/estbfirmware/`
+
+**Files**:
+- `shared/estbfirmware/test_utils.go` (NEW)
+- `shared/estbfirmware/estb_firmware_context_test.go`
+- `shared/estbfirmware/config_change_logs_test.go`
+- `shared/estbfirmware/singleton_filter_test.go`
+- `shared/estbfirmware/time_filter_test.go`
+- `shared/estbfirmware/estbfirmware_unit_test.go`
+- `shared/estbfirmware/percent_filter_test.go`
+- `shared/estbfirmware/estb_converters_test.go`
+- `shared/estbfirmware/ip_filter_test.go`
+- `shared/estbfirmware/reboot_immediately_filter_test.go`
+- `shared/estbfirmware/firmware_config_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 14.2: Shared firmware - Add test_utils.go
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `shared/firmware/`
+
+**Files**:
+- `shared/firmware/test_utils.go` (NEW)
+- `shared/firmware/firmwarerule_test.go`
+- `shared/firmware/firmware_unit_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 14.3: Shared logupload - Add test_utils.go
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `shared/logupload/`
+
+**Files**:
+- `shared/logupload/test_utils.go` (NEW)
+- `shared/logupload/utils_test.go`
+- `shared/logupload/permanent_profile_test.go`
+- `shared/logupload/logupload_test.go`
+- `shared/logupload/telemetry_profile_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 14.4: Shared rfc - Add test_utils.go
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `shared/rfc/`
+
+**Files**:
+- `shared/rfc/test_utils.go` (NEW)
+- `shared/rfc/feature_rule_test.go`
+- `shared/rfc/feature_test.go`
+- `shared/rfc/feature_predicate_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 14.5: Shared change - Add test_utils.go
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `shared/change/`
+
+**Files**:
+- `shared/change/test_utils.go` (NEW)
+- `shared/change/change_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 14.6: Shared coretypes/percentage - Make Idempotent
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `shared/`
+
+**Files**:
+- `shared/coretypes_test.go`
+- `shared/coretypes_clone_test.go`
+- `shared/coretypes_additional_test.go`
+- `shared/percentage_service_test.go`
+- `shared/percentage_service_extra_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+## Phase 15: HTTP Module Enhancement (If Needed)
+
+### Task 15.1: HTTP Module - Verify Mock Support
+**Status**: 🔲 Not Started  
+**Priority**: P2 - Medium  
+**Module**: `http/`
+
+**Description**: HTTP module already has mock patterns. Verify and standardize if needed.
+
+**Files**:
+- `http/webconfig_server_test.go`
+- `http/sat_validator_test.go`
+- `http/xconf_connector_test.go`
+- `http/groupsync_service_connector_test.go`
+- `http/canarymgr_connector_test.go`
+- `http/response_test.go`
+- `http/xcrp_connector_test.go`
+- `http/response_writer_test.go`
+- `http/group_service_connector_test.go`
+- `http/idp_service_connector_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+## Phase 16: Final Validation
+
+### Task 16.1: Full Suite Mock Mode Validation
+**Status**: 🔲 Not Started  
+**Priority**: P0 - Critical  
+
+**Command**:
+```bash
+USE_MOCK_DB=true go test ./... -cover -count=1 -timeout=5m
+```
+
+**Expected**: All tests pass in < 30 seconds
+
+---
+
+### Task 16.2: Full Suite Real DB Validation
+**Status**: 🔲 Not Started  
+**Priority**: P0 - Critical  
+
+**Command**:
+```bash
+USE_MOCK_DB=false go test ./... -cover -count=1 -timeout=45m
+```
+
+**Expected**: All tests pass with Cassandra running
+
+---
+
+### Task 16.3: Coverage Report Generation
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+
+**Commands**:
+```bash
+# Mock mode coverage
+USE_MOCK_DB=true go test ./... -coverprofile=coverage_mock.out -timeout=5m
+go tool cover -html=coverage_mock.out -o coverage_mock.html
+
+# Real mode coverage  
+USE_MOCK_DB=false go test ./... -coverprofile=coverage_real.out -timeout=45m
+go tool cover -html=coverage_real.out -o coverage_real.html
+```
+
+---
+
+---
+
+## Phase 17: Common Package Enhancement
+
+### Task 17.1: Common Package - Add test_utils.go
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `common/`
+
+**Description**: common/struct.go uses GetCachedSimpleDao extensively for:
+- TABLE_APP_SETTINGS
+- TABLE_DCM_RULE  
+- TABLE_ENVIRONMENT
+- TABLE_MODEL
+
+**Files**:
+- `common/test_utils.go` (NEW)
+- `common/struct_test.go`
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+## Phase 18: Additional Infrastructure (GetSimpleDao & GetListingDao)
+
+### Task 18.1: Mock GetSimpleDao Interface
+**Status**: 🔲 Not Started  
+**Priority**: P0 - Critical  
+**Module**: `adminapi/dcm/mocks/`
+
+**Description**: shared/change/change.go uses `db.GetSimpleDao()` (not GetCachedSimpleDao).
+Need to add mock for SimpleDao interface.
+
+**Tables Used**:
+- TABLE_XCONF_CHANGE
+- TABLE_XCONF_APPROVED_CHANGE
+- TABLE_TELEMETRY_CHANGES
+- TABLE_TELEMETRY_APPROVED_CHANGES
+- TABLE_TELEMETRY_TWO_CHANGES
+- TABLE_TELEMETRY_APPROVED_TWO_CHANGES
+
+**Files**:
+- `adminapi/dcm/mocks/mock_simple_dao.go` (NEW)
+- `adminapi/dcm/mocks/mock_simple_dao_test.go` (NEW)
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+### Task 18.2: Mock GetListingDao Interface  
+**Status**: 🔲 Not Started  
+**Priority**: P1 - High  
+**Module**: `adminapi/dcm/mocks/`
+
+**Description**: shared/estbfirmware/config_change_logs.go uses `db.GetListingDao()`.
+Need to add mock for ListingDao interface.
+
+**Tables Used**:
+- TABLE_LOGS (for config change logs)
+
+**Files**:
+- `adminapi/dcm/mocks/mock_listing_dao.go` (NEW)
+- `adminapi/dcm/mocks/mock_listing_dao_test.go` (NEW)
+
+**Coverage After**:
+| Mode | Pass | Coverage |
+|------|------|----------|
+| Mock | 🔲   | --       |
+| Real | 🔲   | --       |
+
+---
+
+## Appendix A: Packages WITHOUT Direct DB Access
+
+These packages have tests but do NOT directly use database operations.
+They may still need TestMain updates if they depend on other packages that use DB.
+
+| Package | Files | Notes |
+|---------|-------|-------|
+| `adminapi/canary/` | 2 test files | No direct DB calls |
+| `adminapi/auth/` | 1 test file | No direct DB calls, but creates WebconfigServer |
+| `adminapi/lockdown/` | 2 test files | No direct DB calls |
+| `taggingapi/config/` | 1 test file | No direct DB calls |
+| `taggingapi/percentage/` | 1 test file | No direct DB calls |
+| `util/` | 9 test files | Pure utility, no DB |
+
+---
+
+## Appendix B: Complete DB Usage Map
+
+### Production Files Using DB
+
+| File | DAO Type | Tables |
+|------|----------|--------|
+| `common/struct.go` | GetCachedSimpleDao | APP_SETTINGS, DCM_RULE, ENVIRONMENT, MODEL |
+| `shared/change/change.go` | GetSimpleDao | XCONF_CHANGE, TELEMETRY_* |
+| `shared/estbfirmware/firmware_config.go` | GetCachedSimpleDao | FIRMWARE_CONFIGS |
+| `shared/estbfirmware/config_change_logs.go` | GetListingDao | LOGS |
+| `shared/estbfirmware/*.go` (filters) | GetCachedSimpleDao | Various |
+| `shared/firmware/firmwarerule.go` | GetCachedSimpleDao | FIRMWARE_RULES |
+| `shared/logupload/logupload.go` | GetCachedSimpleDao | LOG_FILES, LOG_FILE_GROUPS |
+| `shared/logupload/telemetry_profile.go` | GetCachedSimpleDao | TELEMETRY_* |
+| `shared/rfc/feature.go` | GetCachedSimpleDao | XCONF_FEATURE |
+| `taggingapi/tag/tag_member_service.go` | GetCachedSimpleDao | TAGS, TAG_MEMBERS |
+| `adminapi/dcm/*.go` | GetCachedSimpleDao | DCM_RULE, DEVICE_SETTINGS, etc |
+| `adminapi/queries/*.go` | GetCachedSimpleDao | Multiple tables |
+| `adminapi/setting/*.go` | GetCachedSimpleDao | SETTING_PROFILE, SETTING_RULE |
+| `adminapi/telemetry/*.go` | GetCachedSimpleDao | TELEMETRY_* |
+| `adminapi/xcrp/*.go` | GetCachedSimpleDao | XCRP tables |
+
+### Test Files Requiring Mock Support
+
+**Total: 52 test files with direct DB imports**
+
+```
+adminapi/change/          - 4 files
+adminapi/dcm/             - 14 files  
+adminapi/queries/         - 24 files
+adminapi/rfc/feature/     - 3 files
+adminapi/setting/         - 4 files (indirect)
+adminapi/telemetry/       - 9 files
+shared/firmware/          - 1 file
+shared/logupload/         - 1 file
+```
+
+---
+
+## Summary Statistics
+
+| Phase | Module | Tasks | Critical | High | Medium |
+|-------|--------|-------|----------|------|--------|
+| 1 | Infrastructure | 1 | 1 | 0 | 0 |
+| 2 | DCM | 7 | 1 | 5 | 1 |
+| 3 | Queries | 13 | 1 | 10 | 2 |
+| 4 | Telemetry | 4 | 1 | 3 | 0 |
+| 5 | Change | 3 | 1 | 2 | 0 |
+| 6 | Setting | 2 | 1 | 1 | 0 |
+| 7 | Canary | 2 | 1 | 1 | 0 |
+| 8 | RFC | 2 | 1 | 1 | 0 |
+| 9 | Auth | 1 | 1 | 0 | 0 |
+| 10 | XCRP | 2 | 1 | 1 | 0 |
+| 11 | Firmware | 1 | 1 | 0 | 0 |
+| 12 | IP-MacRule | 1 | 1 | 0 | 0 |
+| 13 | Tagging API | 4 | 3 | 1 | 0 |
+| 14 | Shared | 6 | 0 | 6 | 0 |
+| 15 | HTTP | 1 | 0 | 0 | 1 |
+| 16 | Validation | 3 | 2 | 1 | 0 |
+| 17 | Common | 1 | 0 | 1 | 0 |
+| 18 | Additional DAO Mocks | 2 | 1 | 1 | 0 |
+| **Total** | | **56** | **18** | **35** | **4** |

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours


### PR DESCRIPTION
OpenSpec Core Documents:
- proposal.md: Problem statement, goals, 7 requirements
- design.md: Technical architecture, mock patterns
- tasks.md: 56 tasks across 18 phases (P0-P2)
- status.md: Progress tracking

OpenSpec Specs (11 files):
- Module specs: DCM, Queries, Telemetry, Change, Shared, Supporting
- Infrastructure: Mock DAO, Database tables, Use cases
- Patterns: Test patterns, Module inventory

OpenSpec Workflow (.github):
- Prompts: explore, propose, apply, archive
- Skills: openspec-explore, openspec-propose, openspec-apply-change, openspec-archive-change

Key findings:
- 3 DAO types: CachedSimpleDao (39 files), SimpleDao (1), ListingDao (1)
- 100+ test scenarios documented
- 15+ test_utils.go files to create