### PR TITLE
Update xconfwebconfig dependency to v1.0.28

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.18.0
-	github.com/rdkcentral/xconfwebconfig v0.0.0-20260121220436-4e292e8287c9
+	github.com/rdkcentral/xconfwebconfig v1.0.28
 	github.com/sirupsen/logrus v1.9.3
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.uber.org/automaxprocs v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/prometheus/common v0.45.0 h1:2BGz0eBc2hdMDLnO/8n0jeB3oPrt2D08CekT0lne
 github.com/prometheus/common v0.45.0/go.mod h1:YJmSTw9BoKxJplESWWxlbyttQR4uaEcGyv9MZjVOJsY=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
-github.com/rdkcentral/xconfwebconfig v0.0.0-20260121220436-4e292e8287c9 h1:iyK5HHU3H+CNUrkJprsCvqZ7KFKcO6vMo4F0fJcl3rA=
-github.com/rdkcentral/xconfwebconfig v0.0.0-20260121220436-4e292e8287c9/go.mod h1:GU7c3D0c5KEEj/F+1/5O3GUdVIbK5JSlYpFrMKMOZDQ=
+github.com/rdkcentral/xconfwebconfig v1.0.28 h1:35l+rnjWbwdn7J6HmS8OP4AXaSRwDB0cfGh6j0tFUSY=
+github.com/rdkcentral/xconfwebconfig v1.0.28/go.mod h1:wG14bfJYCMN/6pzZG7OpUYrQ3Fet71suEYZ8V4zmrRg=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=


### PR DESCRIPTION
This pull request updates the version of the `github.com/rdkcentral/xconfwebconfig` dependency in the `go.mod` file from a pseudo-version to the official `v1.0.28` release.

Dependency update:

* Updated the `github.com/rdkcentral/xconfwebconfig` dependency from a pseudo-version to the official `v1.0.28` release in `go.mod`, which provide improved stability and compatibility.